### PR TITLE
Windows Installer: Added protobuf to installer

### DIFF
--- a/windows/droneapiWinBuild.bat
+++ b/windows/droneapiWinBuild.bat
@@ -9,6 +9,29 @@ for /f "tokens=*" %%a in (
  set VERSION=%%a
  )
 
+rem -----Get protobuf and unzip-----
+C:\python27\scripts\pip.exe install --download .\ protobuf
+rem get the protobuf fullname
+for /f "tokens=*" %%a in (
+ 'dir /B protobuf-*'
+ ) do (
+ set PROTOBUFFULL=%%a
+ )
+
+rem Use 7zip to unzip files. Works for both 32 and 64 bit versions
+"C:\Program Files\7-zip\7z.exe" x -y %PROTOBUFFULL%
+"C:\Program Files\7-zip\7z.exe" x -y .\dist\protobuf*
+"C:\Program Files (x86)\7-zip\7z.exe" x -y %PROTOBUFFULL%
+"C:\Program Files (x86)\7-zip\7z.exe" x -y .\dist\protobuf*
+
+rem get the protobuf fullname
+for /f "tokens=*" %%a in (
+ 'dir /A:D /B protobuf-*'
+ ) do (
+ set PROTOBUFDIR=%%a
+ )
+xcopy /E /Y %PROTOBUFDIR%\google .\google\
+
 
 rem -----Build the Installer-----
 "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" /dMyAppVersion=%VERSION% -compile droneapi_installer.iss

--- a/windows/droneapi_installer.iss
+++ b/windows/droneapi_installer.iss
@@ -32,6 +32,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Files]
 Source: "..\droneapi\*"; DestDir: "{code:GetMAVProxyPath}\droneapi"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\examples\*"; DestDir: "{code:GetMAVProxyPath}\examples"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "google\*"; DestDir: "{code:GetMAVProxyPath}\google"; Flags: ignoreversion recursesubdirs createallsubdirs
+
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 ; Check if MAVProxy is installed (if so, get the install path)


### PR DESCRIPTION
Protobuf is required by dronekit-python, but is not always included in a MAVProxy installation. Thus this patch gathers up protobuf into the dronekit-python installer.

More background:
MAVProxy is dependant on the mavlink package. Mavlink lists protobuf as "optional", so it may or may not exist in the user's environment.
When MAVProxy is compiled into a setup.exe, protobuf may or may not be included due to the above. Thus we can't assume that it's always included in a MAVProxy environment.