### PR TITLE
Removes observers when API thread terminates.

### DIFF
--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -395,6 +395,16 @@ class HasObservers(object):
                 except Exception as e:
                     print("Error calling observer: ", e)
 
+    def remove_all_observers(self):
+        """
+        Internal function. Do not use.
+
+        This method removes all attached observers.
+
+        .. INTERNAL NOTE: (For subclass use only)
+        """
+        self.__observers = {}
+
 class Vehicle(HasObservers):
     """
     The main vehicle API

--- a/droneapi/module/api.py
+++ b/droneapi/module/api.py
@@ -341,6 +341,11 @@ class APIThread(threading.Thread):
             self.module.mpstate.rx_blacklist.remove('STATUSTEXT')
         except:
             pass # Silently work with old mavproxies
+
+        # Remove all observers.
+        self.module.vehicle.remove_all_observers()
+        self.module.vehicle.unset_mavlink_callback()
+
         self.module.thread_remove(self)
 
     def __str__(self):


### PR DESCRIPTION
See #74.

This adds a private method `remove_all_observers()` to Vehicle. Then we call

```
self.module.vehicle.remove_all_observers()
self.module.vehicle.unset_mavlink_callback()
```

When the API thread terminates. This can't be tested using the test bench, but experimentally it works and helps define a lifecycle for the Vehicle object.