### PR TITLE
Improved MAVLink message example and guide #277

### DIFF
--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -1,0 +1,199 @@
+.. _example_create_attribute:
+
+================================
+Example: Create Attribute in App
+================================
+
+This example shows how you can create attributes for MAVLink messages within your DroneKit-Python script and 
+use them in *in the same way* as the built-in :py:class:`Vehicle <droneapi.lib.Vehicle>` attributes.
+
+Additional information is provided in the guide topic :ref:`mavlink_messages`.
+
+.. tip::
+       
+    This approach is useful when you urgently need to access messages that are not yet supported as 
+    :py:class:`Vehicle <droneapi.lib.Vehicle>` attributes.
+
+    Please :ref:`contribute your code to the API <contributing_api>` so that it is available to 
+    (and can be tested by) the whole DroneKit-Python community. 
+    
+
+
+Running the example
+===================
+
+The vehicle and DroneKit should be set up as described in :ref:`get-started`.
+
+Once MAVProxy is running and the API is loaded, you can start the example by typing: ``api start create_attribute.py``.
+
+.. note:: 
+
+    The command above assumes you started the *MAVProxy* prompt in a directory containing the example script. If not, 
+    you will have to specify the full path to the script (something like):
+    ``api start /home/user/git/dronekit-python/examples/create_attribute/create_attribute.py``.
+
+
+On the *MAVProxy* console you should see (something like):
+
+.. code:: bash
+
+    MAV> api start create_attribute.py
+    STABILIZE> RAW_IMU: time_boot_us=41270000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=1,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=41510000,xacc=0,yacc=0,zacc=-1000,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=41750000,xacc=1,yacc=0,zacc=-1000,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=41990000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=42230000,xacc=0,yacc=0,zacc=-1000,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=42470000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=42710000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=42950000,xacc=0,yacc=0,zacc=-1000,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=43190000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=1,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=43430000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=43670000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=43910000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=44150000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
+    RAW_IMU: time_boot_us=44390000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
+    APIThread-0 exiting...
+
+
+
+How does it work?
+=================
+
+The example first defines a class for the attribute. This has members for each of the values in the message
+(in this case `RAW_IMU <https://pixhawk.ethz.ch/mavlink/#RAW_IMU>`_). It provides an initialiser and a string 
+representation for printing the object.
+
+.. code:: python
+
+    class RawIMU(object):
+        """
+        The RAW IMU readings for the usual 9DOF sensor setup. 
+        This contains the true raw values without any scaling to allow data capture and system debugging.
+    
+        The message definition is here: https://pixhawk.ethz.ch/mavlink/#RAW_IMU
+    
+        :param time_boot_us: Timestamp (microseconds since system boot). #Note, not milliseconds as per spec
+        :param xacc: X acceleration (mg)
+        :param yacc: Y acceleration (mg)
+        :param zacc: Z acceleration (mg)
+        :param xgyro: Angular speed around X axis (millirad /sec)
+        :param ygyro: Angular speed around Y axis (millirad /sec)
+        :param zgyro: Angular speed around Z axis (millirad /sec)
+        :param xmag: X Magnetic field (milli tesla)
+        :param ymag: Y Magnetic field (milli tesla)
+        :param zmag: Z Magnetic field (milli tesla)    
+        """
+
+        def __init__(self, time_boot_us, xacc, yacc, zacc, xygro, ygyro, zgyro, xmag, ymag, zmag):
+            """
+            RawIMU object constructor.
+            """
+            self.time_boot_us = time_boot_us
+            self.xacc = xacc
+            self.yacc = yacc
+            self.zacc = zacc
+            self.xgyro = zgyro
+            self.ygyro = ygyro
+            self.zgyro = zgyro
+            self.xmag = xmag        
+            self.ymag = ymag
+            self.zmag = zmag      
+        
+        def __str__(self):
+            """
+            String representation of the RawIMU object
+            """
+            return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc,     self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
+
+The script should then create an instance of the class and add it as an attribute to the vehicle object retrieved from the local connection.
+All values in the new attribute should be set to ``None`` so that it is obvious to users when no messages have been received. 
+
+.. code:: python
+
+    # Get an instance of the API endpoint
+    api = local_connect()
+    # Get the connected vehicle (currently only one vehicle can be returned).
+    vehicle = api.get_vehicles()[0]
+
+    #Create an Vehicle.raw_imu object and set all values to None.
+    vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
+    
+We can set a callback to intercept MAVLink messages using :py:func:`Vehicle.set_mavlink_callback() <droneapi.lib.Vehicle.set_mavlink_callback>` 
+as shown below. 
+
+.. code:: python
+
+    def mavrx_debug_handler(message):
+        """
+        Handler for MAVLink messages.
+        """
+        #Handle raw_imu messages
+        mav_raw_imu_handler(message)
+
+    # Set MAVLink callback handler (after getting Vehicle instance)
+    vehicle.set_mavlink_callback(mavrx_debug_handler)
+
+For clarity we have separated the handling code for the RAW_IMU message into ``mav_raw_imu_handler()``.  The handler simply checks the message type and 
+(for the correct messages) writes the values into the attribute. It then calls ``vehicle.notify_observers('raw_imu')`` to notify all observers of this attribute type.
+    
+.. code:: python
+
+    def mav_raw_imu_handler(message):
+        """
+        Writes received message to the (newly attached) vehicle.raw_imu object and notifies observers.
+        """
+        messagetype=str(message).split('{')[0].strip()
+        if messagetype=='RAW_IMU':
+            vehicle.raw_imu.time_boot_us=message.time_usec
+            vehicle.raw_imu.xacc=message.xacc
+            vehicle.raw_imu.yacc=message.yacc
+            vehicle.raw_imu.zacc=message.zacc
+            vehicle.raw_imu.xgyro=message.xgyro
+            vehicle.raw_imu.ygyro=message.ygyro
+            vehicle.raw_imu.zgyro=message.zgyro
+            vehicle.raw_imu.xmag=message.xmag
+            vehicle.raw_imu.ymag=message.ymag
+            vehicle.raw_imu.zmag=message.zmag
+
+           #Add Notify all observers of new message.
+            vehicle.notify_observers('raw_imu') 
+
+        
+At this point the ``Vehicle.raw_imu`` attribute can be treated the same as any other attribute for the duration of the session.
+You can query the attribute to get any of the values, and even add an observer as shown:
+
+
+.. code:: python
+
+    #Callback to print the raw_imu
+    def raw_imu_callback(rawimu):
+        print vehicle.raw_imu
+
+
+    #Add observer for the vehicle's current location
+    vehicle.add_attribute_observer('raw_imu', raw_imu_callback)
+
+
+.. note::
+
+    It is not possible to reliably use this approach to create independent modules because:
+
+    * Only one MAVLink callback can be set at a time in the running program (``set_mavlink_callback()``) 
+    * There is no reliable way to import modules without adding them properly to the Python environment.
+
+
+
+Known issues
+============
+
+This code has no known issues.
+
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/dronekit/dronekit-python/blob/master/examples/create_attribute/create_attribute.py>`_):
+
+.. literalinclude:: ../../examples/create_attribute/create_attribute.py
+   :language: python
+

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -18,6 +18,7 @@ during missions and outside missions using custom commands.
    Guided Movement and Commands <guided-set-speed-yaw-demo>
    Basic Mission <mission_basic>
    Mission Import/Export <mission_import_export>
+   Create Attribute in App <create_attribute>
    Follow Me (Linux only)<follow_me>
    Drone Delivery <drone_delivery>
    Flight Replay <flight_replay>

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -17,3 +17,4 @@ The guide contains how-to documentation for using the DroneKit-Python API. These
     copter/guided_mode
     Missions <auto_mode>
     debugging
+    mavlink_messages

--- a/docs/guide/mavlink_messages.rst
+++ b/docs/guide/mavlink_messages.rst
@@ -1,0 +1,86 @@
+.. _mavlink_messages:
+
+================
+MAVLink Messages
+================
+
+Some useful MAVLink messages sent by the autopilot are not (yet) directly available to DroneKit-Python scripts
+through the :ref:`observable attributes <vehicle_state_observe_attributes>` in :py:class:`Vehicle <droneapi.lib.Vehicle>`.
+
+This topic shows how you can intercept MAVLink messages using 
+:py:func:`Vehicle.set_mavlink_callback() <droneapi.lib.Vehicle.set_mavlink_callback>`.
+
+.. tip::
+
+    :ref:`example_create_attribute` shows how you can extend this approach to create a new :py:class:`Vehicle <droneapi.lib.Vehicle>`
+    attribute in your client code.
+
+    
+
+.. _mavlink_messages_set_mavlink_callback:
+
+Creating the message observer
+=============================
+
+The :py:func:`Vehicle.set_mavlink_callback() <droneapi.lib.Vehicle.set_mavlink_callback>` method provides asynchronous 
+notification when any *MAVLink* packet is received from the connected vehicle.
+
+The code snippet below shows how to set a “demo” callback function as the callback handler:
+
+.. code:: python
+
+    # Demo callback handler for raw MAVLink messages
+    def mavrx_debug_handler(message):
+        print type(message)
+        print message
+        
+
+    # Set MAVLink callback handler (after getting Vehicle instance)                     
+    vehicle.set_mavlink_callback(mavrx_debug_handler)
+
+.. note::
+
+    DroneKit-Python only supports a single MAVLink message observer at a time. This can be removed or replaced 
+    with a different observer.    
+    
+The messages are `classes <https://www.samba.org/tridge/UAV/pymavlink/apidocs/classIndex.html>`_ from the `pymavlink <http://www.qgroundcontrol.org/mavlink/pymavlink>`_ library. 
+The output of the code above looks something like:
+
+.. code:: bash
+
+    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_rangefinder_message'>
+    RANGEFINDER {distance : 0.0899999961257, voltage : 0.00900000054389}
+    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_terrain_report_message'>
+    TERRAIN_REPORT {lat : -353632610, lon : 1491652299, spacing : 100, terrain_height : 583.88470459, current_height : 0.0, pending : 0, loaded : 504}
+    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_ekf_status_report_message'>
+    EKF_STATUS_REPORT {flags : 933, velocity_variance : 0.0, pos_horiz_variance : 0.0, pos_vert_variance : 0.000532002304681, compass_variance : 0.00632426189259, terrain_alt_variance : 0.0}
+    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_vibration_message'>
+    VIBRATION {time_usec : 88430000, vibration_x : 0.0, vibration_y : 0.0, vibration_z : 0.0, clipping_0 : 0, clipping_1 : 0, clipping_2 : 0}
+    ...
+    
+You can access the message fields directly. For example, to access the ``RANGEFINDER`` message your handler might look like this:
+
+.. code:: python
+
+    # Handler for message: RANGEFINDER {distance : 0.0899999961257, voltage : 0.00900000054389}
+    def mavrx_debug_handler(message):
+        messagetype=str(message).split('{')[0].strip()
+        if messagetype=='RANGEFINDER':
+            print 'distance: %s' % message.distance
+            print 'voltage: %s' % message.voltage
+
+
+
+    
+
+
+Clearing the observer
+=====================
+
+The observer is unset by calling :py:func:`Vehicle.unset_mavlink_callback <droneapi.lib.Vehicle.unset_mavlink_callback>`.
+
+The observer will also be removed when the thread exits.
+
+
+    
+    

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -79,13 +79,13 @@ Attributes will also return  ``None`` if the associated hardware is not present 
     and `optical flow sensors <http://dev.ardupilot.com/using-sitl-for-ardupilot-testing/#adding_a_virtual_optical_flow_sensor>`_.
 
 
-	
+
 .. todo:: we need to be able to verify mount_status works/setup.
 
 
 
 .. _vehicle_state_set_attributes:
-	
+
 Setting attributes
 ------------------
 
@@ -106,7 +106,7 @@ then forces DroneKit to send outstanding messages.
 
     After ``flush()`` returns the message is guaranteed to have been sent to the autopilot, but it is **not guaranteed to succeed**. 
     For example, vehicle arming can fail if the vehicle doesn't pass pre-arming checks.
-	
+
     While the autopilot does send information about the success (or failure) of the request, this is `not currently handled by DroneKit <https://github.com/dronekit/dronekit-python/issues/114>`_.
 
 
@@ -161,20 +161,20 @@ For example, the following code can be used in the callback to only print output
 .. code:: python
 
     last_rangefinder_distance=0
-	
+
     def rangefinder_callback(rangefinder):
         global last_rangefinder_distance
         if last_rangefinder_distance == round(vehicle.rangefinder.distance, 1):
             return
         last_rangefinder_distance = round(vehicle.rangefinder.distance, 1)
         print " Rangefinder (metres): %s" % last_rangefinder_distance
-	
+
 
     vehicle.add_attribute_observer('rangefinder', rangefinder_callback)	
 
 
 
-.. _vehicle_state_parameters:	
+.. _vehicle_state_parameters:
 
 Parameters
 ==========
@@ -209,7 +209,7 @@ throttle at which the motors will keep spinning.
 
     
 
-	
+
 Setting parameters
 ------------------
 
@@ -228,7 +228,7 @@ Observing parameter changes
 ---------------------------
 
 At time of writing :py:class:`Parameters <droneapi.lib.Parameters>` does `not support <https://github.com/dronekit/dronekit-python/issues/107>`_ observing parameter changes.
-		
+
 .. todo:: 
 
     Check to see if observers have been implemented and if so, update the information here, in about, and in Vehicle class:
@@ -271,40 +271,6 @@ cases where the "proper" API is missing some needed functionality.
 If you have to use these methods please `provide feedback explaining why <https://github.com/dronekit/dronekit-python/issues>`_.
 
 
-.. _vehicle_state_set_mavlink_callback:
-
-MAVLink Message Observer
-------------------------
-
-The :py:func:`Vehicle.set_mavlink_callback() <droneapi.lib.Vehicle.set_mavlink_callback>` method provides asynchronous 
-notification when any *MAVLink* packet is received by this vehicle. The notification can be stopped by 
-calling :py:func:`unset_mavlink_callback() <droneapi.lib.Vehicle.unset_mavlink_callback>` to remove the callback.
-
-
-.. tip::
-
-    Use :ref:`attribute observers <vehicle_state_observe_attributes>` instead of this method where possible. 
-
-
-The code snippet below shows how to set and clear a "demo" callback function as the callback handler:
-
-.. code:: python
-
-    # Demo callback handler for raw MAVLink messages
-    def mavrx_debug_handler(message):
-        print "Received", message
-
-    # Set MAVLink callback handler (after getting Vehicle instance)                     
-    vehicle.set_mavlink_callback(mavrx_debug_handler)
-
-    # Wait to allow the callback to be invoked before it is removed. 
-    time.sleep(1)
-
-    # Remove the MAVLink callback handler. Callback will not be
-    # called after this point.
-    vehicle.unset_mavlink_callback()
-
-
 .. _vehicle_state_channel_override:
 
 Channel Overrides
@@ -323,7 +289,7 @@ The values of the first four channels map to the main flight controls: 1=Roll, 2
 `Plane <http://plane.ardupilot.com/wiki/arduplane-parameters/#rcmap__parameters>`_, 
 `Copter <http://copter.ardupilot.com/wiki/configuration/arducopter-parameters/#rcmap__parameters>`_ , 
 `Rover <http://rover.ardupilot.com/wiki/apmrover2-parameters/#rcmap__parameters>`_).
-	
+
 The remaining channel values are configurable, and their purpose can be determined using the 
 `RCn_FUNCTION parameters <http://plane.ardupilot.com/wiki/flight-features/channel-output-functions/>`_. 
 In general a value of 0 set for a specific ``RCn_FUNCTION`` indicates that the channel can be 
@@ -337,7 +303,7 @@ An example of setting and clearing overrides is given below:
     # Override the channel for roll and yaw
     vehicle.channel_override = { "1" : 900, "4" : 1000 }
     vehicle.flush()
-	
+
     #print current override values
     print "Current overrides are:", vehicle.channel_override
 
@@ -350,7 +316,7 @@ An example of setting and clearing overrides is given below:
 
 
 
-	
+
 .. _api-information-known-issues:
 
 Known issues
@@ -362,7 +328,6 @@ Below are a number of bugs and known issues related to vehicle state and setting
 * `#60 Attribute observer callbacks are called with heartbeat until disabled - after first called  <https://github.com/dronekit/dronekit-python/issues/60>`_
 * `#107 Add implementation for observer methods in Parameter class <https://github.com/dronekit/dronekit-python/issues/107>`_ 
 * `#114 DroneKit has no method for detecting command failure <https://github.com/dronekit/dronekit-python/issues/114>`_
-* `#115 No way to disable the callback set_mavlink_callback <https://github.com/dronekit/dronekit-python/issues/115>`_
 
 
 Other API issues and improvement suggestions can viewed on `github here <https://github.com/dronekit/dronekit-python/issues>`_. 

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -1,0 +1,113 @@
+"""
+create_attribute.py:
+
+Demonstrates how to create attributes for MAVLink messages within your DroneKit-Python script 
+and use them in the same way as the built-in Vehicle attributes.
+
+The code adds a new attribute to the Vehicle class, populating it with information from RAW_IMU messages 
+intercepted using set_mavlink_callback.
+
+Full documentation is provided at http://python.dronekit.io/examples/create_attribute.html
+"""
+
+from droneapi.lib import VehicleMode
+from pymavlink import mavutil
+import time
+
+class RawIMU(object):
+    """
+    The RAW IMU readings for the usual 9DOF sensor setup. 
+    This contains the true raw values without any scaling to allow data capture and system debugging.
+    
+    The message definition is here: https://pixhawk.ethz.ch/mavlink/#RAW_IMU
+    
+    :param time_boot_us: Timestamp (microseconds since system boot). #Note, not milliseconds as per spec
+    :param xacc: X acceleration (mg)
+    :param yacc: Y acceleration (mg)
+    :param zacc: Z acceleration (mg)
+    :param xgyro: Angular speed around X axis (millirad /sec)
+    :param ygyro: Angular speed around Y axis (millirad /sec)
+    :param zgyro: Angular speed around Z axis (millirad /sec)
+    :param xmag: X Magnetic field (milli tesla)
+    :param ymag: Y Magnetic field (milli tesla)
+    :param zmag: Z Magnetic field (milli tesla)    
+    """
+    def __init__(self, time_boot_us, xacc, yacc, zacc, xygro, ygyro, zgyro, xmag, ymag, zmag):
+        """
+        RawIMU object constructor.
+        """
+        self.time_boot_us = time_boot_us
+        self.xacc = xacc
+        self.yacc = yacc
+        self.zacc = zacc
+        self.xgyro = zgyro
+        self.ygyro = ygyro
+        self.zgyro = zgyro
+        self.xmag = xmag        
+        self.ymag = ymag
+        self.zmag = zmag      
+        
+    def __str__(self):
+        """
+        String representation used to print the RawIMU object. 
+        """
+        return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc, self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
+
+   
+# Get an instance of the API endpoint
+api = local_connect()
+# Get the connected vehicle (currently only one vehicle can be returned).
+vehicle = api.get_vehicles()[0]
+
+#Create an Vehicle.raw_imu object and set all values to None.
+vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
+
+
+def mav_raw_imu_handler(message):
+    """
+    Writes received message to the (newly attached) vehicle.raw_imu object and notifies observers.
+    """
+    messagetype=str(message).split('{')[0].strip()
+    if messagetype=='RAW_IMU':
+        vehicle.raw_imu.time_boot_us=message.time_usec
+        vehicle.raw_imu.xacc=message.xacc
+        vehicle.raw_imu.yacc=message.yacc
+        vehicle.raw_imu.zacc=message.zacc
+        vehicle.raw_imu.xgyro=message.xgyro
+        vehicle.raw_imu.ygyro=message.ygyro
+        vehicle.raw_imu.zgyro=message.zgyro
+        vehicle.raw_imu.xmag=message.xmag
+        vehicle.raw_imu.ymag=message.ymag
+        vehicle.raw_imu.zmag=message.zmag
+
+        #Add Notify all observers of new message.
+        vehicle.notify_observers('raw_imu') 
+
+        
+def mavrx_debug_handler(message):
+    """
+    Handler for MAVLink messages.
+    """
+    #Handle raw_imu messages
+    mav_raw_imu_handler(message)
+
+# Set MAVLink callback handler (after getting Vehicle instance)
+vehicle.set_mavlink_callback(mavrx_debug_handler)
+
+"""
+From this point vehicle.raw_imu can be used just like any other attribute.
+"""
+
+#Callback to print the raw_imu
+def raw_imu_callback(rawimu):
+    print vehicle.raw_imu
+
+
+#Add observer for the vehicle's current location
+vehicle.add_attribute_observer('raw_imu', raw_imu_callback)
+
+print 'Display RAW_IMU messages for 5 seconds and then exit.'
+time.sleep(5)
+
+#The observer can be unset using ``vehicle.unset_mavlink_callback()`` OR 
+# ``vehicle.set_mavlink_callback(None)``. #It is automatically removed when the thread exits.


### PR DESCRIPTION
@tcr3dr @mrpollo So this moves the set_mavlink_callback docs out of the vehicle_state guide and into its own guide doc. In addition it adds a (pretty cool :-) ) example and docs of how to add your own attributes to the Vehicle class in a script. 

Unlike the other examples, the example doc has quite a lot of explanation - I decided that in this case it made sense because it extends the callback functionality. I have linked to it from the guide though.

Let me know what you think.