### PR TITLE
Tmp modecompare 278

### DIFF
--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -247,6 +247,17 @@ class VehicleMode(object):
 
         # Set the vehicle into auto mode
         vehicle.mode = VehicleMode("AUTO")
+        vehicle.flush()  # Flush to guarantee the write is complete
+
+    After setting the mode you can test that it has changed by comparing the ``name`` member:
+
+    .. code:: python
+
+        # Test that the mode has changed
+        while not vehicle.mode.name=='GUIDED':
+            print "Waiting for mode change ..."
+            time.sleep(1)
+        
 
     For more information on getting/setting/observing the :py:attr:`Vehicle.mode <droneapi.lib.Vehicle.mode>` (and other attributes) see the :ref:`attributes guide <vehicle_state_attributes>`.
 

--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -249,15 +249,16 @@ class VehicleMode(object):
         vehicle.mode = VehicleMode("AUTO")
         vehicle.flush()  # Flush to guarantee the write is complete
 
-    After setting the mode you can test that it has changed by comparing the ``name`` member:
+    Mode comparisons must be performed against the ``Vehicle.mode.name`` member. The code below shows how
+    to test that the mode has actually changed:
 
     .. code:: python
 
         # Test that the mode has changed
-        while not vehicle.mode.name=='GUIDED':
+        while not vehicle.mode.name=='AUTO':
             print "Waiting for mode change ..."
             time.sleep(1)
-        
+         
 
     For more information on getting/setting/observing the :py:attr:`Vehicle.mode <droneapi.lib.Vehicle.mode>` (and other attributes) see the :ref:`attributes guide <vehicle_state_attributes>`.
 


### PR DESCRIPTION
Add explicit text that you need to compare against **Vehicle.mode.name** (ie you can't compare ``Vehicle.mode == VehicleMode('GUIDED')`` ). You can however compare ``Vehicle.mode.name == VehicleMode('GUIDED').name``

I've put this in the API reference for the Mode because we don't have a better place. I made a conscious decision to not document attributes separately in the guide, but instead to put documentation in the class (if there is one) and the Vehicle attribute itself if there isn't an associated class. 

This was to address the specific comment https://github.com/dronekit/dronekit-python/issues/278#issuecomment-130138613