### PR TITLE
VehicleMode is now comparable

### DIFF
--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -285,6 +285,12 @@ class VehicleMode(object):
     def __str__(self):
         return "VehicleMode:%s" % self.name
 
+    def __eq__(self, other):
+        return self.name == other
+
+    def __ne__(self, other):
+        return self.name != other
+
 class APIConnection(object):
     """
     An API provider.
@@ -524,7 +530,7 @@ class Vehicle(HasObservers):
 
     .. py:attribute:: rangefinder
 
-        :py:class:`Rangefinder` distance and voltage values. 
+        :py:class:`Rangefinder` distance and voltage values.
 
 
     .. py:attribute:: channel_override
@@ -750,7 +756,7 @@ class Vehicle(HasObservers):
             vehicle.set_mavlink_callback(mavrx_debug_handler)
 
         :param callback: The callback function to be invoked when a raw MAVLink message is received.
-		
+
         """
         self.mavrx_callback = callback
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,9 +1,18 @@
 import mock
 from mock import MagicMock
-import dronekit
-from dronekit import FakeAPI
+from nose.tools import eq_, assert_not_equal
+import droneapi
+from droneapi.module.api import APIModule
+from droneapi.lib import VehicleMode
 from nose.tools import assert_equals
 
-def test_mode():
-    api = FakeAPI(MagicMock())
-    assert_equals(len(api.get_vehicles()), 1)
+def test_get_vehicles():
+    api = APIModule(MagicMock())
+    res = api.get_connection()
+    eq_(len(res.get_vehicles()), 1)
+
+def test_vehicle_mode_eq():
+    eq_(VehicleMode('GUIDED'), VehicleMode('GUIDED'))
+
+def test_vehicle_mode_neq():
+    assert_not_equal(VehicleMode('AUTO'), VehicleMode('GUIDED'))

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,18 +1,16 @@
 import mock
 from mock import MagicMock
-from nose.tools import eq_, assert_not_equal
-import droneapi
-from droneapi.module.api import APIModule
-from droneapi.lib import VehicleMode
-from nose.tools import assert_equals
+import dronekit
+from dronekit.lib import VehicleMode
+from dronekit import FakeAPI
+from nose.tools import assert_equals, assert_not_equals
 
-def test_get_vehicles():
-    api = APIModule(MagicMock())
-    res = api.get_connection()
-    eq_(len(res.get_vehicles()), 1)
+def test_mode():
+    api = FakeAPI(MagicMock())
+    assert_equals(len(api.get_vehicles()), 1)
 
 def test_vehicle_mode_eq():
-    eq_(VehicleMode('GUIDED'), VehicleMode('GUIDED'))
+    assert_equals(VehicleMode('GUIDED'), VehicleMode('GUIDED'))
 
 def test_vehicle_mode_neq():
-    assert_not_equal(VehicleMode('AUTO'), VehicleMode('GUIDED'))
+    assert_not_equals(VehicleMode('AUTO'), VehicleMode('GUIDED'))


### PR DESCRIPTION
this change makes it safe to compare `VehicleMode` objects with other `VehicleMode` objects and with strings

```python
vehicle.mode == VehicleMode('GUIDED')
vehicle.mode == 'GUIDED' 
```

```python
vehicle.mode != VehicleMode('GUIDED')
vehicle.mode != 'GUIDED' 
```


fixes #278 