### PR TITLE
Adds stand-alone channel overrides example

### DIFF
--- a/docs/examples/channel_overrides.rst
+++ b/docs/examples/channel_overrides.rst
@@ -32,7 +32,7 @@ In summary, after cloning the repository:
 
    .. code-block:: bash
 
-       cd dronekit-python\examples\channel_overrides\
+       cd dronekit-python/examples/channel_overrides/
 
 
 #. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:

--- a/docs/examples/channel_overrides.rst
+++ b/docs/examples/channel_overrides.rst
@@ -1,0 +1,90 @@
+.. _example_channel_overrides:
+.. _vehicle_state_channel_override:
+
+==========================
+Example: Channel Overrides
+==========================
+
+This example shows how to get channel information and to get/set channel-override information.
+
+.. warning::
+
+    Channel overrides (a.k.a "RC overrides") are highly discommended (they are primarily implemented 
+    for simulating user input and when implementing certain types of joystick control).
+
+    Instead use the appropriate MAVLink commands like DO_SET_SERVO/DO_SET_RELAY, or more generally set 
+    the desired position or direction/speed.
+
+    If you have no choice but to use a channel-override please explain why in a 
+    `github issue <https://github.com/dronekit/dronekit-python/issues>`_ and we will attempt to find a 
+    better alternative.
+    
+
+Running the example
+===================
+
+The example can be run as described in :doc:`running_examples` (which in turn assumes that the vehicle
+and DroneKit have been set up as described in :ref:`get-started`). 
+
+In summary, after cloning the repository:
+
+#. Navigate to the example folder as shown:
+
+   .. code-block:: bash
+
+       cd dronekit-python\examples\channel_overrides\
+
+
+#. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:
+
+   .. code-block:: bash
+
+       python channel_overrides.py --connect 127.0.0.1:14550
+
+   .. note::
+   
+       The examples uses the ``--connect`` parameter to pass the :ref:`connection string <get_started_connect_string>` into the script. 
+       The command above would be used to connect to :ref:`SITL <sitl_setup>` running on the local machine via UDP port 14550.
+          
+
+
+On the command prompt you should see (something like):
+
+.. code:: bash
+
+    Overriding RC channels for roll and yaw
+     Current overrides are: {'1': 900, '4': 1000}
+     Channel default values: {'1': 1500, '3': 1000, '2': 1500, '5': 1800, '4': 1500, '7': 1000, '6': 1000, '8': 1800}
+     Cancelling override
+
+
+
+How does it work?
+=================
+
+Get the default values of the channels using the :py:attr:`channel_readback <dronekit.lib.Vehicle.channel_readback>` attribute. 
+
+You can over-ride these values using the :py:attr:`channel_override <dronekit.lib.Vehicle.channel_override>` attribute. This takes a dictionary argument defining the RC *output* channels to be overridden (specified by channel number), and their new values.  Channels that are not specified in the dictionary are not overridden. All multi-channel updates are atomic. To cancel an override call ``channel_override`` again, setting zero for the overridden channels.
+
+The values of the first four channels map to the main flight controls: 1=Roll, 2=Pitch, 3=Throttle, 4=Yaw (the mapping is defined in ``RCMAP_`` parameters in 
+`Plane <http://plane.ardupilot.com/wiki/arduplane-parameters/#rcmap__parameters>`_, 
+`Copter <http://copter.ardupilot.com/wiki/configuration/arducopter-parameters/#rcmap__parameters>`_ , 
+`Rover <http://rover.ardupilot.com/wiki/apmrover2-parameters/#rcmap__parameters>`_).
+
+The remaining channel values are configurable, and their purpose can be determined using the 
+`RCn_FUNCTION parameters <http://plane.ardupilot.com/wiki/flight-features/channel-output-functions/>`_. 
+In general a value of 0 set for a specific ``RCn_FUNCTION`` indicates that the channel can be 
+`mission controlled <http://plane.ardupilot.com/wiki/flight-features/channel-output-functions/#disabled>`_ (i.e. it will not directly be 
+controlled by normal autopilot code).
+
+
+
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/dronekit/dronekit-python/blob/master/examples/channel_overrides/channel_overrides.py>`_):
+
+.. literalinclude:: ../../examples/channel_overrides/channel_overrides.py
+   :language: python
+

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -22,6 +22,8 @@ during missions and outside missions using custom commands.
    Follow Me (Linux only)<follow_me>
    Drone Delivery <drone_delivery>
    Flight Replay <flight_replay>
+   Channel Overrides <channel_overrides>
+   
 
 
 

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -4,7 +4,7 @@
 Example: Vehicle State
 ======================
 
-This example shows how to get/set vehicle attribute, parameter and channel-override information, 
+This example shows how to get/set vehicle attribute and parameter information, 
 how to observe vehicle attribute changes, and how to get the home position.
 
 The guide topic :ref:`vehicle-information` provides a more detailed explanation of how the API
@@ -14,23 +14,38 @@ should be used.
 Running the example
 ===================
 
-The vehicle and DroneKit should be set up as described in :ref:`get-started`.
+The example can be run as described in :doc:`running_examples` (which in turn assumes that the vehicle
+and DroneKit have been set up as described in :ref:`get-started`).
 
 If you're using a simulated vehicle remember to :ref:`disable arming checks <disable-arming-checks>` so 
-that the example can run. You can also `add a virtual rangefinder <http://dev.ardupilot.com/wiki/simulation-2/sitl-simulator-software-in-the-loop/using-sitl-for-ardupilot-testing/#adding_a_virtual_rangefinder>`_
+that the example can run. You can also 
+`add a virtual rangefinder <http://dev.ardupilot.com/wiki/using-sitl-for-ardupilot-testing/#adding_a_virtual_rangefinder>`_
 (otherwise the :py:attr:`Vehicle.rangefinder <dronekit.lib.Vehicle.rangefinder>` attribute may return values of ``None`` for the distance
 and voltage). 
 
-Once MAVProxy is running and the API is loaded, you can start the example by typing: ``api start vehicle_state.py``.
+In summary, after cloning the repository:
 
-.. note:: 
+#. Navigate to the example folder as shown:
 
-    The command above assumes you started the *MAVProxy* prompt in a directory containing the example script. If not, 
-    you will have to specify the full path to the script (something like):
-    ``api start /home/user/git/dronekit-python/examples/vehicle_state/vehicle_state.py``.
+   .. code-block:: bash
+
+       cd dronekit-python\examples\vehicle_state\
 
 
-On the *MAVProxy* console you should see (something like):
+#. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:
+
+   .. code-block:: bash
+
+       python vehicle_state.py --connect 127.0.0.1:14550
+
+   .. note::
+   
+       The examples uses the ``--connect`` parameter to pass the :ref:`connection string <get_started_connect_string>` into the script. 
+       The command above would be used to connect to :ref:`SITL <sitl_setup>` running on the local machine via UDP port 14550.
+          
+
+
+On the command prompt you should see (something like):
 
 .. code:: bash
 
@@ -83,12 +98,6 @@ On the *MAVProxy* console you should see (something like):
     ...
     Raw MAVLink message:  SCALED_PRESSURE {time_boot_ms : 895340, press_abs : 945.038024902, press_diff : 0.0, temperature : 2600}
     Remove the MAVLink callback handler (stop getting messages)
-	
-	
-    Overriding RC channels for roll and yaw
-     Current overrides are: {'1': 900, '4': 1000}
-     Channel default values: {'1': 1500, '3': 1000, '2': 1500, '5': 1800, '4': 1500, '7': 1000, '6': 1000, '8': 1800}
-     Cancelling override
 
     Reset vehicle attributes/parameters and exit
     Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
@@ -133,7 +142,7 @@ Source code
 ===========
 
 The full source code at documentation build-time is listed below (`current version on github <https://github.com/dronekit/dronekit-python/blob/master/examples/vehicle_state/vehicle_state.py>`_):
-	
+
 .. literalinclude:: ../../examples/vehicle_state/vehicle_state.py
    :language: python
-	
+

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -49,63 +49,56 @@ On the command prompt you should see (something like):
 
 .. code:: bash
 
-    MAV> api start vehicle_state.py
-    STABILIZE>
+    \dronekit-python\examples\vehicle_state>vehicle_state.py
+
+    Connecting to vehicle on: 127.0.0.1:14550
+    >>> ☺APM:Copter V3.3-rc1 (d66eec53)
+    >>> ☺Frame: QUAD
+
+    Accumulating vehicle attribute messages (2s)
 
     Get all vehicle attribute values:
-     Location:  Attitude: Attitude:pitch=-0.00405988190323,yaw=-0.0973932668567,roll=-0.00393210304901
-     Velocity: [0.06, -0.07, 0.0]
+     Location: Location:lat=-35.3632601,lon=149.1652279,alt=-0.00999999977648,is_relative=False
+     Attitude: Attitude:pitch=0.00486609805375,yaw=0.489637970924,roll=0.00645932834595
+     Velocity: [-0.12, 0.06, 0.0]
      GPS: GPSInfo:fix=3,num_sat=10
      Groundspeed: 0.0
      Airspeed: 0.0
      Mount status: [None, None, None]
-     Battery: Battery voltage: 12590, current: 0, level: 99
-     Rangefinder: Rangefinder: distance=0.189999997616, voltage=0.0190000012517
-     Rangefinder distance: 0.189999997616
-     Rangefinder voltage: 0.0190000012517
+     Battery: Battery:voltage=0.0,current=None,level=None
+     Rangefinder: Rangefinder: distance=None, voltage=None
+     Rangefinder distance: None
+     Rangefinder voltage: None
      Mode: STABILIZE
      Armed: False
+
     Set Vehicle.mode=GUIDED (currently: STABILIZE)
      Waiting for mode change ...
-    Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
-    GUIDED> Mode GUIDED
+
     Set Vehicle.armed=True (currently: False)
      Waiting for arming...
-    APM: ARMING MOTORS
-    APM: Initialising APM...
-    Got MAVLink msg: COMMAND_ACK {command : 400, result : 0}
-    ARMED
+    >>> ☺ARMING MOTORS
+    >>> ☺Initialising APM...
+     Waiting for arming...
 
     Add mode attribute observer for Vehicle.mode
      Set mode=STABILIZE (currently: GUIDED)
      Wait 2s so callback invoked before observer removed
-    Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
-    STABILIZE> Mode STABILIZE
+     CALLBACK: Mode changed to:  STABILIZE
      CALLBACK: Mode changed to:  STABILIZE
 
     Get home location
-    Requesting 0 waypoints t=Fri May 15 11:35:58 2015 now=Fri May 15 11:35:58 2015
-     Home WP: MISSION_ITEM {target_system : 255, target_component : 0, seq : 0, frame : 0, command : 16, current : 0, autocontinue : 1, param1 : 0.0, param2 : 0.0, param3 : 0.0, param4 : 0.0, x : -35.3632621765, y : 149.165237427, z : 583.729980469}
+     Home WP: MISSION_ITEM {target_system : 255, target_component : 0, seq : 0, frame : 0, command : 16, current : 0, autocontinue : 1, param1 : 0.0, param2 : 0.0, param3 : 0.0, param4 : 0.0, x : -35.3632583618, y : 149.165222168, z : 583.729980469}
 
     Read vehicle param 'THR_MIN': 130.0
     Write vehicle param 'THR_MIN' : 10
-    timeout setting THR_MIN to 10.000000
     Read new value of param 'THR_MIN': 10.0
 
-    Set MAVLink callback handler (start receiving all MAVLink messages)
-    Wait 1s so mavrx_debug_handler has a chance to be called before it is removed
-    Raw MAVLink message:  RAW_IMU {time_usec : 894620000, xacc : -3, yacc : 10, zacc : -999, xgyro : 1, ygyro : 0, zgyro : 1, xmag : 153, ymag : 52, zmag : -364}
-    ...
-    Raw MAVLink message:  SCALED_PRESSURE {time_boot_ms : 895340, press_abs : 945.038024902, press_diff : 0.0, temperature : 2600}
-    Remove the MAVLink callback handler (stop getting messages)
-
     Reset vehicle attributes/parameters and exit
-    Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
-    APM: DISARMING MOTORS
-    Got MAVLink msg: COMMAND_ACK {command : 400, result : 0}
-    DISARMED
-    timeout setting THR_MIN to 130.000000
-    APIThread-0 exiting...
+    >>> ☺DISARMING MOTORS
+
+    Close vehicle object
+
 
 
 

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -29,7 +29,7 @@ In summary, after cloning the repository:
 
    .. code-block:: bash
 
-       cd dronekit-python\examples\vehicle_state\
+       cd dronekit-python/examples/vehicle_state/
 
 
 #. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:
@@ -49,11 +49,9 @@ On the command prompt you should see (something like):
 
 .. code:: bash
 
-    \dronekit-python\examples\vehicle_state>vehicle_state.py
-
     Connecting to vehicle on: 127.0.0.1:14550
-    >>> ☺APM:Copter V3.3-rc1 (d66eec53)
-    >>> ☺Frame: QUAD
+    >>> APM:Copter V3.3-rc1 (d66eec53)
+    >>> Frame: QUAD
 
     Accumulating vehicle attribute messages (2s)
 

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -79,13 +79,13 @@ Attributes will also return  ``None`` if the associated hardware is not present 
     and `optical flow sensors <http://dev.ardupilot.com/using-sitl-for-ardupilot-testing/#adding_a_virtual_optical_flow_sensor>`_.
 
 
-	
+
 .. todo:: we need to be able to verify mount_status works/setup.
 
 
 
 .. _vehicle_state_set_attributes:
-	
+
 Setting attributes
 ------------------
 
@@ -106,7 +106,7 @@ then forces DroneKit to send outstanding messages.
 
     After ``flush()`` returns the message is guaranteed to have been sent to the autopilot, but it is **not guaranteed to succeed**. 
     For example, vehicle arming can fail if the vehicle doesn't pass pre-arming checks.
-	
+
     While the autopilot does send information about the success (or failure) of the request, this is `not currently handled by DroneKit <https://github.com/dronekit/dronekit-python/issues/114>`_.
 
 
@@ -161,20 +161,20 @@ For example, the following code can be used in the callback to only print output
 .. code:: python
 
     last_rangefinder_distance=0
-	
+
     def rangefinder_callback(rangefinder):
         global last_rangefinder_distance
         if last_rangefinder_distance == round(vehicle.rangefinder.distance, 1):
             return
         last_rangefinder_distance = round(vehicle.rangefinder.distance, 1)
         print " Rangefinder (metres): %s" % last_rangefinder_distance
-	
+
 
     vehicle.add_attribute_observer('rangefinder', rangefinder_callback)	
 
 
 
-.. _vehicle_state_parameters:	
+.. _vehicle_state_parameters:
 
 Parameters
 ==========
@@ -209,7 +209,7 @@ throttle at which the motors will keep spinning.
 
     
 
-	
+
 Setting parameters
 ------------------
 
@@ -228,7 +228,7 @@ Observing parameter changes
 ---------------------------
 
 At time of writing :py:class:`Parameters <dronekit.lib.Parameters>` does `not support <https://github.com/dronekit/dronekit-python/issues/107>`_ observing parameter changes.
-		
+
 .. todo:: 
 
     Check to see if observers have been implemented and if so, update the information here, in about, and in Vehicle class:
@@ -305,52 +305,7 @@ The code snippet below shows how to set and clear a "demo" callback function as 
     vehicle.unset_mavlink_callback()
 
 
-.. _vehicle_state_channel_override:
 
-Channel Overrides
------------------
-
-.. warning::
-
-    Channel Overrides may be useful for simulating user input and when implementing certain types of joystick control. 
-    They should not be used for direct control of the vehicle unless there is no other choice!
-
-    Instead use the appropriate MAVLink commands like DO_SET_SERVO/DO_SET_RELAY, or more generally set the desired position or direction/speed.
-
-The :py:attr:`channel_override <dronekit.lib.Vehicle.channel_override>` attribute takes a dictionary argument defining the RC *output* channels to be overridden (specified by channel number), and their new values.  Channels that are not specified in the dictionary are not overridden. All multi-channel updates are atomic. To cancel an override call ``channel_override`` again, setting zero for the overridden channels.
-
-The values of the first four channels map to the main flight controls: 1=Roll, 2=Pitch, 3=Throttle, 4=Yaw (the mapping is defined in ``RCMAP_`` parameters in 
-`Plane <http://plane.ardupilot.com/wiki/arduplane-parameters/#rcmap__parameters>`_, 
-`Copter <http://copter.ardupilot.com/wiki/configuration/arducopter-parameters/#rcmap__parameters>`_ , 
-`Rover <http://rover.ardupilot.com/wiki/apmrover2-parameters/#rcmap__parameters>`_).
-	
-The remaining channel values are configurable, and their purpose can be determined using the 
-`RCn_FUNCTION parameters <http://plane.ardupilot.com/wiki/flight-features/channel-output-functions/>`_. 
-In general a value of 0 set for a specific ``RCn_FUNCTION`` indicates that the channel can be 
-`mission controlled <http://plane.ardupilot.com/wiki/flight-features/channel-output-functions/#disabled>`_ (i.e. it will not directly be 
-controlled by normal autopilot code).
-
-An example of setting and clearing overrides is given below:
-
-.. code:: python
-    
-    # Override the channel for roll and yaw
-    vehicle.channel_override = { "1" : 900, "4" : 1000 }
-    vehicle.flush()
-	
-    #print current override values
-    print "Current overrides are:", vehicle.channel_override
-
-    # Print channel values (values if overrides removed)
-    print "Channel default values:", vehicle.channel_readback  
-    
-    # Cancel override by setting channels to 0
-    vehicle.channel_override = { "1" : 0, "4" : 0 }
-    vehicle.flush()	
-
-
-
-	
 .. _api-information-known-issues:
 
 Known issues

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -9,8 +9,7 @@ The :py:class:`Vehicle <dronekit.lib.Vehicle>` class exposes *most* state inform
 are accessed though named elements of :py:attr:`Vehicle.parameters <dronekit.lib.Vehicle.parameters>`. 
 
 This topic explains how to get, set and observe vehicle state and parameter information (including getting the 
-:ref:`Home location <vehicle_state_home_location>`). It also describes a few APIs that  
-:ref:`should be used with caution <vehicle_state_disrecommended>`.
+:ref:`Home location <vehicle_state_home_location>`).
 
 .. tip:: You can test most of the code in this topic by running the :ref:`Vehicle State <example-vehicle-state>` example.
 
@@ -136,7 +135,8 @@ Observers are added using :py:func:`Vehicle.add_attribute_observer() <dronekit.l
 specifying the name of the attribute to observe and a callback function. The same string is passed to the callback
 when it is notified. Observers are removed using :py:func:`remove_attribute_observer() <dronekit.lib.Vehicle.remove_attribute_observer>`.
 
-The code snippet below shows how to add (and remove) a callback function to observe :py:attr:`location <dronekit.lib.Vehicle.location>` attribute changes. The two second ``sleep()`` is required because otherwise the observer might be removed before the the callback is first run.
+The code snippet below shows how to add (and remove) a callback function to observe :py:attr:`location <dronekit.lib.Vehicle.location>` 
+attribute changes. The two second ``sleep()`` is required because otherwise the observer might be removed before the the callback is first run.
 
 .. code:: python
      
@@ -145,17 +145,17 @@ The code snippet below shows how to add (and remove) a callback function to obse
         print " CALLBACK: Location changed to: ", vehicle.location
 
     # Add a callback. The first parameter the name of the observed attribute (a string).
-    vehicle.add_attribute_observer('location', location_callback)	
+    vehicle.add_attribute_observer('location', location_callback)
 
     # Wait 2s so callback can be notified before the observer is removed
     time.sleep(2)
 
     # Remove observer - specifying the attribute and previously registered callback function
-    vehicle.remove_attribute_observer('location', location_callback)	
+    vehicle.remove_attribute_observer('location', location_callback)
 
 
-The callback is triggered `every time a message is received from the vehicle <https://github.com/dronekit/dronekit-python/issues/60>`_ 
-(whether or not the observed attribute changes). Callback code may therefore choose to cache the result and only report changes. 
+The callback is triggered every time a message is received from the vehicle (whether or not the observed attribute changes). 
+Callback code may therefore choose to cache the result and only report changes. 
 For example, the following code can be used in the callback to only print output when the value of :py:attr:`Vehicle.rangefinder <dronekit.lib.Vehicle.rangefinder>` changes.
 
 .. code:: python
@@ -170,7 +170,7 @@ For example, the following code can be used in the callback to only print output
         print " Rangefinder (metres): %s" % last_rangefinder_distance
 
 
-    vehicle.add_attribute_observer('rangefinder', rangefinder_callback)	
+    vehicle.add_attribute_observer('rangefinder', rangefinder_callback)
 
 
 
@@ -260,52 +260,6 @@ The returned value is a :py:class:`Command <dronekit.lib.Command>` object.
 
 
 
-.. _vehicle_state_disrecommended:
-
-Discommended APIs
-=================
-
-This section describes methods that we recommend you do not use! In general they are provided to handle the (hopefully rare)
-cases where the "proper" API is missing some needed functionality.
-
-If you have to use these methods please `provide feedback explaining why <https://github.com/dronekit/dronekit-python/issues>`_.
-
-
-.. _vehicle_state_set_mavlink_callback:
-
-MAVLink Message Observer
-------------------------
-
-The :py:func:`Vehicle.set_mavlink_callback() <dronekit.lib.Vehicle.set_mavlink_callback>` method provides asynchronous 
-notification when any *MAVLink* packet is received by this vehicle. The notification can be stopped by 
-calling :py:func:`unset_mavlink_callback() <dronekit.lib.Vehicle.unset_mavlink_callback>` to remove the callback.
-
-
-.. tip::
-
-    Use :ref:`attribute observers <vehicle_state_observe_attributes>` instead of this method where possible. 
-
-
-The code snippet below shows how to set and clear a "demo" callback function as the callback handler:
-
-.. code:: python
-
-    # Demo callback handler for raw MAVLink messages
-    def mavrx_debug_handler(message):
-        print "Received", message
-
-    # Set MAVLink callback handler (after getting Vehicle instance)                     
-    vehicle.set_mavlink_callback(mavrx_debug_handler)
-
-    # Wait to allow the callback to be invoked before it is removed. 
-    time.sleep(1)
-
-    # Remove the MAVLink callback handler. Callback will not be
-    # called after this point.
-    vehicle.unset_mavlink_callback()
-
-
-
 .. _api-information-known-issues:
 
 Known issues
@@ -313,11 +267,9 @@ Known issues
 
 Below are a number of bugs and known issues related to vehicle state and settings:
 
-* `#12 Timeout error when setting a parameter <https://github.com/dronekit/dronekit-python/issues/12>`_
 * `#60 Attribute observer callbacks are called with heartbeat until disabled - after first called  <https://github.com/dronekit/dronekit-python/issues/60>`_
 * `#107 Add implementation for observer methods in Parameter class <https://github.com/dronekit/dronekit-python/issues/107>`_ 
 * `#114 DroneKit has no method for detecting command failure <https://github.com/dronekit/dronekit-python/issues/114>`_
-* `#115 No way to disable the callback set_mavlink_callback <https://github.com/dronekit/dronekit-python/issues/115>`_
 
 
 Other API issues and improvement suggestions can viewed on `github here <https://github.com/dronekit/dronekit-python/issues>`_. 

--- a/examples/channel_overrides/channel_overrides.py
+++ b/examples/channel_overrides/channel_overrides.py
@@ -20,7 +20,7 @@ import time
 
 #Set up option parsing to get connection string
 import argparse  
-parser = argparse.ArgumentParser(description='Print out vehicle state information. Connects to SITL on local PC by default.')
+parser = argparse.ArgumentParser(description='Example showing how to set and clear vehicle channel-override information. Connects to SITL on local PC by default.')
 parser.add_argument('--connect', default='127.0.0.1:14550',
                    help="vehicle connection target. Default '127.0.0.1:14550'")
 args = parser.parse_args()
@@ -46,3 +46,9 @@ vehicle.flush()
 
 # Short wait before exiting
 time.sleep(5)
+
+#Close vehicle object before exiting script
+print "Close vehicle object"
+vehicle.close()
+
+print("Completed")

--- a/examples/channel_overrides/channel_overrides.py
+++ b/examples/channel_overrides/channel_overrides.py
@@ -1,0 +1,48 @@
+"""
+channel_overrides.py: 
+
+Demonstrates how set and clear channel-override information.
+
+# NOTE: 
+Channel overrides (a.k.a "RC overrides") are highly discommended (they are primarily implemented 
+for simulating user input and when implementing certain types of joystick control).
+
+They are provided for development purposes. Please raise an issue explaining why you need them
+and we will try to find a better alternative: https://github.com/dronekit/dronekit-python/issues
+
+
+Full documentation is provided at http://python.dronekit.io/examples/channel_overrides.html
+"""
+from dronekit import connect
+from dronekit.lib import VehicleMode
+from pymavlink import mavutil
+import time
+
+#Set up option parsing to get connection string
+import argparse  
+parser = argparse.ArgumentParser(description='Print out vehicle state information. Connects to SITL on local PC by default.')
+parser.add_argument('--connect', default='127.0.0.1:14550',
+                   help="vehicle connection target. Default '127.0.0.1:14550'")
+args = parser.parse_args()
+
+
+# Connect to the Vehicle
+print 'Connecting to vehicle on: %s' % args.connect
+vehicle = connect(args.connect, await_params=True)
+
+#Override channels
+print "\nOverriding RC channels for roll and yaw"
+vehicle.channel_override = { "1" : 900, "4" : 1000 }
+vehicle.flush()
+print " Current overrides are:", vehicle.channel_override
+
+# Get all original channel values (before override)
+print " Channel default values:", vehicle.channel_readback  
+
+# Cancel override by setting channels to 0
+print " Cancelling override"
+vehicle.channel_override = { "1" : 0, "4" : 0 }
+vehicle.flush()
+
+# Short wait before exiting
+time.sleep(5)

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -23,8 +23,14 @@ args = parser.parse_args()
 print "\nConnecting to vehicle on: %s" % args.connect
 vehicle = connect(args.connect, await_params=True)
 
-print "\nAccumulating vehicle attribute messages (2s)"
-time.sleep(2)
+if vehicle.mode.name == "INITIALISING":
+    print "Waiting for vehicle to initialise"
+    time.sleep(1)
+
+print "\nAccumulating vehicle attribute messages"
+while vehicle.attitude.pitch==None:  #Attitude is fairly quick to propagate
+    print " ..."    
+    time.sleep(1)
 
 # Get all vehicle attributes (state)
 print "\nGet all vehicle attribute values:"
@@ -52,6 +58,13 @@ while not vehicle.mode.name=='GUIDED':  #Wait until mode has changed
     print " Waiting for mode change ..."
     time.sleep(1)
 
+
+# Check we have a good gps fix (required to arm)
+while vehicle.gps_0.fix_type < 2:
+    print "Waiting for GPS fix=3 (needed to arm):", vehicle.gps_0.fix_type
+    time.sleep(1)
+    
+    
 print "\nSet Vehicle.armed=True (currently: %s)" % vehicle.armed 
 vehicle.armed = True
 vehicle.flush()
@@ -105,3 +118,5 @@ vehicle.flush()
 #Close vehicle object before exiting script
 print "\nClose vehicle object"
 vehicle.close()
+
+print("Completed")

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -1,7 +1,7 @@
 """
 vehicle_state.py: 
 
-Demonstrates how to get and set vehicle state, parameter and channel-override information, 
+Demonstrates how to get and set vehicle state and parameter information, 
 and how to observe vehicle attribute (state) changes.
 
 Full documentation is provided at http://python.dronekit.io/examples/vehicle_state.html
@@ -20,8 +20,11 @@ args = parser.parse_args()
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % args.connect
+print "\nConnecting to vehicle on: %s" % args.connect
 vehicle = connect(args.connect, await_params=True)
+
+print "\nAccumulating vehicle attribute messages (2s)"
+time.sleep(2)
 
 # Get all vehicle attributes (state)
 print "\nGet all vehicle attribute values:"
@@ -42,14 +45,14 @@ print " Armed: %s" % vehicle.armed    # settable
 
 
 # Set vehicle mode and armed attributes (the only settable attributes)
-print "Set Vehicle.mode=GUIDED (currently: %s)" % vehicle.mode.name 
+print "\nSet Vehicle.mode=GUIDED (currently: %s)" % vehicle.mode.name 
 vehicle.mode = VehicleMode("GUIDED")
 vehicle.flush()  # Flush to guarantee that previous writes to the vehicle have taken place
 while not vehicle.mode.name=='GUIDED':  #Wait until mode has changed
     print " Waiting for mode change ..."
     time.sleep(1)
 
-print "Set Vehicle.armed=True (currently: %s)" % vehicle.armed 
+print "\nSet Vehicle.armed=True (currently: %s)" % vehicle.armed 
 vehicle.armed = True
 vehicle.flush()
 while not vehicle.armed:
@@ -91,22 +94,14 @@ vehicle.flush()
 print "Read new value of param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
 
 
-# Demo callback handler for raw MAVLink messages
-def mavrx_debug_handler(message):
-    print "Raw MAVLink message: ", message
-
-print "\nSet MAVLink callback handler (start receiving all MAVLink messages)"                 
-vehicle.set_mavlink_callback(mavrx_debug_handler)
-
-print "Wait 1s so mavrx_debug_handler has a chance to be called before it is removed"
-time.sleep(1)
-
-print "Remove the MAVLink callback handler (stop getting messages)"  
-vehicle.unset_mavlink_callback()
-
 ## Reset variables to sensible values.
 print "\nReset vehicle attributes/parameters and exit"
 vehicle.mode = VehicleMode("STABILIZE")
 vehicle.armed = False
 vehicle.parameters['THR_MIN']=130
 vehicle.flush()
+
+
+#Close vehicle object before exiting script
+print "\nClose vehicle object"
+vehicle.close()


### PR DESCRIPTION
This adds a standalone channel overrides example and example document to address #329. This completes the job of #330 by removing the channel override information from the vehicle state example and guide pages. It also tidies up the "running the example" section on the vehicle state example.

Note that the new example and example page has a big disclaimer saying that this shouldn't be used, but that if you need to you should post an issue explaining why so we can find a better alternative. I don't have a separate guide section on this because it isn't something we want to promote.

This has not yet been tested. The example page(s) "guess" at what the output should look like. I will test and update those sections as soon as there is a DK version I can use. 