### PR TITLE
Adds Solo-specific system_status impl.

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -193,8 +193,11 @@ class MPFakeState:
             self.level = m.battery_remaining
             self._notify_attribute_listeners('battery')
 
+        self.system_status = None
+
         @message_default('HEARTBEAT')
         def listener(self, name, m):
+            self.system_status = m.system_status
             self._notify_attribute_listeners('mode', 'armed')
 
         self.last_waypoint = 0

--- a/dronekit/module/api.py
+++ b/dronekit/module/api.py
@@ -200,6 +200,10 @@ class MPVehicle(Vehicle):
             self.__master.arducopter_disarm()
 
     @property
+    def system_status(self):
+        return self.__module.system_status
+
+    @property
     def groundspeed(self):
         return self.__module.groundspeed
 


### PR DESCRIPTION
This is not meant to be a final implementation of system_status, but a stub one that allows us to achieve parity with Solo's private DK fork. We can continue to refine this design in the later RC's.

This will precede 2.0.0b4, and will probably be the last beta on master.