### PR TITLE
Adds interfaces for Dronekit-SITL

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -548,6 +548,7 @@ class MPFakeState:
         t = Thread(target=mavlink_thread)
         t.daemon = True
         t.start()
+        self.mavlink_thread = t
 
         # Wait for first heartbeat.
         while True:
@@ -576,6 +577,13 @@ class MPFakeState:
                 time.sleep(0.1)
 
         return self.api
+
+    def close(self):
+        # TODO this can block forever if parameters continue to be added
+        self.exiting = True
+        while not self.out_queue.empty():
+            time.sleep(0.1)
+        self.master.close()
 
 def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle):
     import dronekit.module.api as api

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -302,16 +302,20 @@ class MPFakeState:
         name = name.upper()
         value = float(value)
         success = False
-        while retries > 0:
-            retries -= 1
+        remaining = retries
+        while True:
             self.master.param_set_send(name.upper(), value)
             tstart = time.time()
+            if remaining == 0:
+                break
+            remaining -= 1
             while time.time() - tstart < 1:
-                if self.mav_param[name] == value:
+                if name in self.mav_param and self.mav_param[name] == value:
                     return True
                 time.sleep(0.1)
         
-        errprinter("timeout setting parameter %s to %f" % (name, value))
+        if retries > 0:
+            errprinter("timeout setting parameter %s to %f" % (name, value))
         return False
 
     def __on_change(self, *args):

--- a/dronekit/module/api.py
+++ b/dronekit/module/api.py
@@ -133,6 +133,9 @@ class MPVehicle(Vehicle):
         self._waypoints = None
         self.wpts_dirty = False
 
+    def close(self):
+        return self.__module.close()
+
     def flush(self):
         if self.wpts_dirty:
             self.__module.send_all_waypoints()

--- a/dronekit/module/api.py
+++ b/dronekit/module/api.py
@@ -32,6 +32,11 @@ class MPParameters(Parameters):
         self.wait_valid()
         self.__module.mpstate.functions.param_set(name, value)
 
+    def set(self, name, value, retries=3, await_valid=False):
+        if await_valid:
+            self.wait_valid()
+        return self.__module.mpstate.param_set(name, value, retries=retries)
+
     def wait_valid(self):
         '''Block the calling thread until parameters have been downloaded'''
         # FIXME this is a super crufty spin-wait, also we should give the user the option of specifying a timeout

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension
 import platform
 
-version = '2.0.0b3'
+version = '2.0.0b4'
 
 setup(name='dronekit',
       zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension
 import platform
 
-version = '2.0.0b4'
+version = '2.0.0b5'
 
 setup(name='dronekit',
       zip_safe=True,


### PR DESCRIPTION
*Goal:* Enable pysim support for Copter 3.2 and Solo builds in DroneKit-SITL. https://github.com/dronekit/dronekit-sitl/pull/47

This adds

```
vehicle.parameters.set(name, value, retries=*)
```

This allows the number of retries to be specified. 0 is fire and forget. Normal is 3, i.e. wait three intervals up to three seconds each to see if it is loaded. This exposes the underlying machinery for parameter setting via `vehicle.parameters[name] = value`.

This also adds

```
vehicle.close()
```

Whose behavior is approximately correct, though should probably go through a round of bikeshedding to ensure it's correct.