### PR TITLE
Add vehicle.close to vehicle_state example

### DIFF
--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -109,3 +109,9 @@ vehicle.mode = VehicleMode("STABILIZE")
 vehicle.armed = False
 vehicle.parameters['THR_MIN']=130
 vehicle.flush()
+
+#Close vehicle object before exiting script
+print "Close vehicle object"
+vehicle.close()
+
+print("Completed")


### PR DESCRIPTION
Minor fix the the vehicle_state.py example to ensure vehicle.close() is called before exiting.