### PR TITLE
Improve about section of docs 

### DIFF
--- a/docs/about/github_latest_release.txt
+++ b/docs/about/github_latest_release.txt
@@ -17,7 +17,7 @@ Source Code
 -----------
 
 
-Source code is available at <https://github.com/dronekit/dronekit-python/releases/tag/v1.5.0>.
+Source code is available `here <https://github.com/dronekit/dronekit-python/releases/tag/v1.5.0>`_.
 
 * View `**commits** included in this release <https://github.com/dronekit/dronekit-python/compare/v1.4.3...v1.5.0>`_
 * View `**bugs** closed by this release <https://github.com/dronekit/dronekit-python/issues?utf8=%E2%9C%93&q=is%3Aclosed+created%3A%3E2015-08-10+is%3Aissue+>`_

--- a/docs/about/overview.rst
+++ b/docs/about/overview.rst
@@ -18,9 +18,16 @@ If you want to join the community, then see our :doc:`contributing section <../c
 
 Compatibility
 =============
-DroneKit-Python is compatible with all vehicles using the `MAVLink protocol <http://qgroundcontrol.org/mavlink/start>`_ (including most vehicles made by 3DR and other members of the `DroneCode foundation <https://www.dronecode.org/about/project-members>`_). It runs on Linux, Mac OS X, or Windows. 
+DroneKit-Python is compatible with vehicles that communicate using the `MAVLink protocol <http://qgroundcontrol.org/mavlink/start>`_ (including most vehicles made by `3DR <https://3drobotics.com/>`_ and other members of the `DroneCode foundation <https://www.dronecode.org/about/project-members>`_). It runs on Linux, Mac OS X, or Windows.
 
-In addition to "Air apps", it can be used to create apps that run on a desktop ground station and communicate with ArduPilot over a higher latency RF-link. 
+.. note::
+
+    DroneKit-Python is validated against, and hence *most compatible* with, the `ArduPilot UAV Platform <http://ardupilot.com/>`_. 
+    Vehicles running other autopilots may be be less compatible due to differences in adhererence/interpretation of the MAVLink specification. 
+    Please report any autopilot-specific issues `on Github here <https://github.com/dronekit/dronekit-python/issues>`_.
+
+
+In addition to creating apps that run on companion computers, DroneKit-Python apps can be used on ground stations and communicate with vehicles over a higher latency RF-link. 
 
 
 API features
@@ -29,12 +36,12 @@ API features
 
 The API provides classes and methods to:
 
-- Get a list of connected vehicles.
+- Connect to a vehicle (or multiple vehicles) from a script
 - Get and set vehicle state/telemetry and parameter information.
 - Receive asynchronous notification of state changes.
-- Create and manage waypoint missions (AUTO mode).
 - Guide a UAV to specified position (GUIDED mode).
 - Send arbitrary custom messages to control UAV movement and other hardware (GUIDED mode).
+- Create and manage waypoint missions (AUTO mode).
 - Override RC channel settings.
 
 A complete API reference is available :ref:`here <api_reference>`.

--- a/docs/about/overview.rst
+++ b/docs/about/overview.rst
@@ -2,9 +2,10 @@
 About DroneKit
 ==============
 
-DroneKit-Python is DroneKit's main API for *Air Computing* — allowing developers to create apps that run on an onboard :ref:`companion computer <supported-companion-computers>` and communicate with the `ArduPilot <http://ardupilot.com>`_ flight controller using a low-latency link. *Air apps* can significantly enhance the autopilot, adding greater intelligence to vehicle behaviour, and performing tasks that are computationally intensive or time-sensitive (for example, computer vision, path planning, or 3D modelling). 
+DroneKit-Python allows developers to create apps that run on an onboard :ref:`companion computer <supported-companion-computers>` and communicate with the `ArduPilot <http://ardupilot.com>`_ flight controller using a low-latency link. Onboard apps can significantly enhance the autopilot, adding greater intelligence to vehicle behaviour, and performing tasks that are computationally intensive or time-sensitive (for example, computer vision, path planning, or 3D modelling). DroneKit-Python can also be used for ground station apps, communicating with vehicles over a higher latency RF-link. 
 
-The API communicates with "locally connected" vehicles over MAVLink. It provides programmatic access to a connected vehicle's telemetry, state and parameter information, and enables both mission management and direct control over vehicle movement and operations.
+The API communicates with vehicles over MAVLink. It provides programmatic access to a connected vehicle's telemetry, state and parameter information, and enables both mission management and direct control over vehicle movement and operations.
+
 
 
 Open source community
@@ -26,8 +27,6 @@ DroneKit-Python is compatible with vehicles that communicate using the `MAVLink 
     Vehicles running other autopilots may be be less compatible due to differences in adhererence/interpretation of the MAVLink specification. 
     Please report any autopilot-specific issues `on Github here <https://github.com/dronekit/dronekit-python/issues>`_.
 
-
-In addition to creating apps that run on companion computers, DroneKit-Python apps can be used on ground stations and communicate with vehicles over a higher latency RF-link. 
 
 
 API features

--- a/docs/about/release_notes.rst
+++ b/docs/about/release_notes.rst
@@ -23,12 +23,14 @@ For information about all past releases, please see `this link on Github <https:
 Working with releases
 =======================
 
-The following PyPI commands are useful for working with different version of DroneKit Python: ::
+The following PyPI commands are useful for working with different version of DroneKit Python: 
+
+.. code-block:: bash
 
     pip install dronekit    # Install the latest version
     pip install dronekit --upgrade    # Update to the latest version
     pip show dronekit    # Find out what release you have installed
-    pip install dronekit=1.0.3    # Get a sepcific old release (in this case 1.0.3
-		
+    pip install dronekit==2.0.0rc1    # Get a sepcific old release (in this case 2.0.0rc1)
+
 See `Release History on the package ranking page <http://pypi-ranking.info/module/dronekit#release_history>`_  for a list of all releases available on PyPI.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,9 +7,9 @@
 Welcome to DroneKit-Python's documentation!
 ===========================================
 
-DroneKit's Python API helps you create powerful apps for air-based control of UAVs. These apps run on a UAV's :ref:`Companion Computer <supported-companion-computers>`, and augment the autopilot by performing tasks that are both computationally intensive and require a low-latency link (e.g. computer vision). 
+DroneKit-Python helps you create powerful apps for UAVs. These apps run on a UAV's :ref:`Companion Computer <supported-companion-computers>`, and augment the autopilot by performing tasks that are both computationally intensive and require a low-latency link (e.g. computer vision). 
 
-This documentation provides everything you need to :ref:`get started <get-started>` with DroneKit-Python, including an :doc:`overview <about/overview>` of the API, guide material, a number of demos and examples, and :doc:`API Reference <automodule>`. 
+This documentation provides everything you need to :doc:`get started <guide/getting_started>` with DroneKit-Python, including an :doc:`overview <about/overview>` of the API, guide material, a number of demos and examples, and :doc:`API Reference <automodule>`. 
 
 
 Contents:


### PR DESCRIPTION
This updates the About section of docs for DKPY2. 

1. Tidies the release notes a little. 
1. Updates the overview. 

The major changes were to:

* make it clear that DK is not really compatible with every single MAVLink device. I did this by removing words like "all" and adding a note indicating what we validate against.
* make it clear that we no longer get back a "list of devices" when connecting, and that we can connect to multiple devices from script
* Remove/reduce the "air interface" branding.