### PR TITLE
Changes parameter access behavior to not wait on key lookup.

### DIFF
--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -855,11 +855,9 @@ class Parameters(HasObservers):
         self.__module = module
 
     def __getitem__(self, name):
-        self.wait_valid()
         return self.__module.mav_param[name]
 
     def __setitem__(self, name, value):
-        self.wait_valid()
         self.__module.param_set(name, value)
 
     def set(self, name, value, retries=3, await_valid=False):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension
 import platform
 
-version = '2.0.0rc3'
+version = '2.0.0rc4'
 
 setup(name='dronekit',
       zip_safe=True,


### PR DESCRIPTION
This behavior seems fairly "magical", requires a hack in Solo, and also .wait_valid() in terms of parameters should be generalized in the `.wait('parameters')` magic (#342).