### PR TITLE
Adds baud parameter to connect(). Fixes #393.

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -572,8 +572,8 @@ class MPFakeState:
             time.sleep(0.1)
         self.master.close()
 
-def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle, rate=4):
-    state = MPFakeState(mavutil.mavlink_connection(ip), vehicle_class=vehicle_class)
+def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle, rate=4, baud=115200):
+    state = MPFakeState(mavutil.mavlink_connection(ip, baud=baud), vehicle_class=vehicle_class)
     state.status_printer = status_printer
     state.prepare(await_params=await_params, rate=rate)
     return state.vehicle

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -431,11 +431,7 @@ class MPFakeState:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after read timeout')
-                                try:
-                                    self.master.close()
-                                except:
-                                    pass
-                                self.master = mavutil.mavlink_connection(self.master.address)
+                                self.master.reset()
                                 continue
 
                             # If connection reset (closed), stop polling.
@@ -452,11 +448,7 @@ class MPFakeState:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after send timeout')
-                                try:
-                                    self.master.close()
-                                except:
-                                    pass
-                                self.master = mavutil.mavlink_connection(self.master.address)
+                                self.master.reset()
                                 continue
 
                             # If connection reset (closed), stop polling.


### PR DESCRIPTION
This adds a `baud=` parameter to connect(), with the exact semantics of `mavlink_connection`.

We also adopt the mavutil reconnection logic rather than forcibly recreating the network, in order to preserve the baud (and what other) properties. The Windows test needs this most often due to it running slowly, so if Appveyor passes, then we are successful.