### PR TITLE
Extracts MPState object logic into Vehicle. Implements wait_ready.

### DIFF
--- a/docs/guide/auto_mode.rst
+++ b/docs/guide/auto_mode.rst
@@ -103,13 +103,7 @@ To clear a mission you call :py:func:`clear() <dronekit.lib.CommandSequence.clea
 
     # Call clear() on Vehicle.commands and upload the command to the vehicle.
     cmds.clear()
-    vehicle.flush()
-
-    # Reset the Vehicle.commands from the vehicle.
-    cmds.download()
-    cmds.wait_ready()
-
-.. warning:: 
+    cmds.upload()
 
 .. note:: 
 
@@ -185,9 +179,6 @@ modify them as needed, then clear ``Vehicle.commands`` and upload the list as a 
 
     # Clear the current mission (command is sent when we call upload()) 
     cmds.clear()
-    vehicle.flush()
-    cmds.download()
-    cmds.wait_ready()
 
     #Write the modified mission and flush to the vehicle
     for cmd in missionlist:
@@ -279,28 +270,26 @@ The implementation calls ``readmission()`` (below) to import the mission from a 
 clears the existing mission and uploads the new version. 
 
 Adding mission commands is discussed :ref:`here in the guide <auto_mode_adding_command>`.
-  
+
 .. code:: python
 
     def upload_mission(aFileName):
-        """
-        Upload a mission from a file.
-        """
-        missionlist = readmission(aFileName)
-        #clear existing mission
-        print 'Clear mission'
-        cmds = vehicle.commands
-        cmds.download()
-        cmds.wait_ready()
-        cmds.clear()
-        vehicle.flush()
-        print 'ClearCount: %s' % cmds.count
-        #add new mission
-        cmds.download()
-        cmds.wait_ready()
-        for command in missionlist:
-            cmds.add(command)
-        vehicle.flush()
+            """
+            Upload a mission from a file. 
+            """
+            #Read mission from file
+            missionlist = readmission(aFileName)
+            
+            print "\nUpload mission from a file: %s" % import_mission_filename
+            #Clear existing mission from vehicle
+            print ' Clear mission'
+            cmds = vehicle.commands
+            cmds.clear()
+            #Add new mission to vehicle
+            for command in missionlist:
+                cmds.add(command)
+            print ' Upload mission'
+            vehicle.commands.upload()
 
 
 ``readmission()`` reads a mission from the specified file and returns a list of :py:class:`Command <dronekit.lib.Command>` objects. 

--- a/docs/guide/copter/guided_mode.rst
+++ b/docs/guide/copter/guided_mode.rst
@@ -355,7 +355,7 @@ The *home location* is updated immediately in ArduPilot, but the change may not 
     # Reloads the home location in GCSs
     cmds = vehicle.commands
     cmds.download()
-    cmds.wait_valid()
+    cmds.wait_ready()
     print " Home WP: %s" % cmds[0]
 
 .. _guided_mode_copter_responses:

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -266,6 +266,28 @@ At time of writing :py:class:`Parameters <dronekit.lib.Parameters>` does `not su
 
 
 
+.. _vehicle_state_home_location:
+
+Home location
+=============
+
+The *Home location* is set when a vehicle is armed and first gets a good location fix from the GPS. The location is used 
+as the target when the vehicle does a "return to launch". In Copter missions (and most Plane) missions, the altitude of 
+waypoints is set relative to this position.
+
+Unlike other vehicle state information, the home location is accessed as the 0 index value of 
+:py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>`:
+
+.. code:: python
+    
+    cmds = vehicle.commands
+    cmds.download()
+    cmds.wait_ready()
+    print " Home WP: %s" % cmds[0]
+
+The returned value is a :py:class:`Command <dronekit.lib.Command>` object.
+
+
 
 .. _api-information-known-issues:
 

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -196,7 +196,7 @@ The behaviour of :py:attr:`Vehicle.home_location <dronekit.lib.Vehicle.home_loca
     
       cmds = vehicle.commands
       cmds.download()
-      cmds.wait_valid()
+      cmds.wait_ready()
       print " Home Location: %s" % vehicle.home_location
 
   The returned value is a :py:class:`LocationGlobal <dronekit.lib.LocationGlobal>` object 
@@ -263,29 +263,6 @@ At time of writing :py:class:`Parameters <dronekit.lib.Parameters>` does `not su
     Check to see if observers have been implemented and if so, update the information here, in about, and in Vehicle class:
     https://github.com/dronekit/dronekit-python/issues/107
 
-
-
-
-.. _vehicle_state_home_location:
-
-Home location
-=============
-
-The *Home location* is set when a vehicle is armed and first gets a good location fix from the GPS. The location is used 
-as the target when the vehicle does a "return to launch". In Copter missions (and most Plane) missions, the altitude of 
-waypoints is set relative to this position.
-
-Unlike other vehicle state information, the home location is accessed as the 0 index value of 
-:py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>`:
-
-.. code:: python
-    
-    cmds = vehicle.commands
-    cmds.download()
-    cmds.wait_ready()
-    print " Home WP: %s" % cmds[0]
-
-The returned value is a :py:class:`Command <dronekit.lib.Command>` object.
 
 
 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -431,7 +431,7 @@ class MPFakeState:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after read timeout')
-                                if hasattr(self.master, 'reset'):
+                                if self.master.reset:
                                     self.master.reset()
                                 else:
                                     try:
@@ -455,7 +455,7 @@ class MPFakeState:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after send timeout')
-                                if hasattr(self.master, 'reset'):
+                                if self.master.reset:
                                     self.master.reset()
                                 else:
                                     try:

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -182,5 +182,5 @@ def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Veh
     
     vehicle.initialize(rate=rate)
     if await_params:
-        vehicle.wait_ready()
+        vehicle.wait_ready('parameters', 'gps_0')
     return vehicle

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -142,12 +142,11 @@ class MAVHandler:
         self.mavlink_thread = t
 
     def fix_targets(self, message):
-        pass
-        # """Set correct target IDs for our vehicle"""
-        # if hasattr(message, 'target_system'):
-        #     message.target_system = self.target_system
-        # if hasattr(message, 'target_component'):
-        #     message.target_component = self.target_component
+        """Set correct target IDs for our vehicle"""
+        if hasattr(message, 'target_system'):
+            message.target_system = self.target_system
+        if hasattr(message, 'target_component'):
+            message.target_component = self.target_component
 
     def loop_listener(self, fn):
         """
@@ -173,15 +172,15 @@ class MAVHandler:
         self.master.close()
 
 def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle, rate=4, baud=115200):
-    socket = mavutil.mavlink_connection(ip, baud=baud)
-    handler = MAVHandler(socket)
+    handler = MAVHandler(mavutil.mavlink_connection(ip, baud=baud))
     vehicle = vehicle_class(handler)
 
     if status_printer:
-        print('ok')
         @vehicle.message_listener('STATUSTEXT')
         def listener(self, name, m):
             status_printer(re.sub(r'(^|\n)', '>>> ', m.text.rstrip()))
     
-    vehicle.initialize(await_params=await_params, rate=rate)
+    vehicle.initialize(rate=rate)
+    if await_params:
+        vehicle.wait_ready()
     return vehicle

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -37,16 +37,11 @@ class MavWriter():
         errprinter('writer should not have had a read request')
         os._exit(43)
 
-def request_data_stream_send(master, rate=1):
-    master.mav.request_data_stream_send(master.target_system, master.target_component,
-                                        mavutil.mavlink.MAV_DATA_STREAM_ALL, rate, 1)
-
-class MPFakeState:
+class MAVHandler:
     def __init__(self, master, vehicle_class=Vehicle):
         self.vehicle_class = vehicle_class
 
         self.master = master
-        self.vehicle = None
 
         # TODO get rid of "master" object as exposed,
         # keep it private, expose something smaller for dronekit
@@ -57,53 +52,9 @@ class MPFakeState:
         self.target_system = 0
         self.target_component = 0
 
-        # Parameters
-        self.mav_param = {} 
-
-        # Event loop listeners.
+        # Listeners.
         self.loop_listeners = []
-
-        self.vehicle = self.vehicle_class(self)
-
-    def fix_targets(self, message):
-        pass
-        # """Set correct target IDs for our vehicle"""
-        # if hasattr(message, 'target_system'):
-        #     message.target_system = self.target_system
-        # if hasattr(message, 'target_component'):
-        #     message.target_component = self.target_component
-
-    def module(self, which):
-        # psyche
-        return self
-
-    def __on_change(self, *args):
-        for a in args:
-            self.vehicle.notify_observers(a)
-
-    def _notify_attribute_listeners(self, *args):
-        return self.__on_change(*args)
-
-    def mavlink_packet(self, m):
-        typ = m.get_type()
-
-        # Downstream.
-        for fn in self.vehicle.message_listeners.get(typ, []):
-            fn(self.vehicle, typ, m)
-        for fn in self.vehicle.message_listeners.get('*', []):
-            fn(self.vehicle, typ, m)
-
-    def loop_listener(self, fn):
-        """
-        Decorator for event loop.
-        """
-        self.loop_listeners.append(fn)
-
-    def prepare(self, await_params=False, rate=None):
-        # errprinter('Await heartbeat.')
-        # TODO this should be more rigious. How to avoid
-        #   invalid MAVLink prefix '73'
-        #   invalid MAVLink prefix '13'
+        self.message_listeners = []
 
         import atexit
         self.exiting = False
@@ -125,6 +76,7 @@ class MPFakeState:
                     while True:
                         try:
                             msg = self.out_queue.get_nowait()
+                            self.fix_targets(msg)
                             self.master.write(msg)
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
@@ -166,13 +118,17 @@ class MPFakeState:
                             # If connection reset (closed), stop polling.
                             return
                         except Exception as e:
-                            # TODO debug these.
+                            # TODO this should be more rigious. How to avoid
+                            #   invalid MAVLink prefix '73'
+                            #   invalid MAVLink prefix '13'
                             # errprinter('mav recv error:', e)
                             msg = None
                         if not msg:
                             break
 
-                        self.mavlink_packet(msg)
+                        # Message listeners.
+                        for fn in self.message_listeners:
+                            fn(self, msg)
 
             except Exception as e:
                 # http://bugs.python.org/issue1856
@@ -181,42 +137,33 @@ class MPFakeState:
                 else:
                     raise
 
-
         t = Thread(target=mavlink_thread)
         t.daemon = True
-        t.start()
         self.mavlink_thread = t
 
-        # Wait for first heartbeat.
-        while True:
-            try:
-                self.master.wait_heartbeat()
-                break
-            except mavutil.mavlink.MAVError:
-                continue
-        heartbeat_started = True
+    def fix_targets(self, message):
+        pass
+        # """Set correct target IDs for our vehicle"""
+        # if hasattr(message, 'target_system'):
+        #     message.target_system = self.target_system
+        # if hasattr(message, 'target_component'):
+        #     message.target_component = self.target_component
 
-        # Request a list of all parameters.
-        if rate != None:
-            request_data_stream_send(self.master, rate=rate)
-        while True:
-            # This fn actually rate limits itself to every 2s.
-            # Just retry with persistence to get our first param stream.
-            self.master.param_fetch_all()
-            time.sleep(0.1)
-            if self.vehicle._params_count > -1:
-                break
+    def loop_listener(self, fn):
+        """
+        Decorator for event loop.
+        """
+        self.loop_listeners.append(fn)
 
-        # We now should get parameters streaming in.
-        # We may not get the full set; we leave the logic to mavlink_thread
-        # to determine what params we yet need. Wait if await_params is True.
-        if await_params:
-            while not self.vehicle._params_loaded:
-                time.sleep(0.1)
+    def message_listener(self, fn):
+        """
+        Decorator for message inputs.
+        """
+        self.message_listeners.append(fn)
 
-            # Await GPS lock
-            while self.vehicle._fix_type == None:
-                time.sleep(0.1)
+    def start(self):
+        if not self.mavlink_thread.is_alive():
+            self.mavlink_thread.start()
 
     def close(self):
         # TODO this can block forever if parameters continue to be added
@@ -226,13 +173,15 @@ class MPFakeState:
         self.master.close()
 
 def connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle, rate=4, baud=115200):
-    state = MPFakeState(mavutil.mavlink_connection(ip, baud=baud), vehicle_class=vehicle_class)
+    socket = mavutil.mavlink_connection(ip, baud=baud)
+    handler = MAVHandler(socket)
+    vehicle = vehicle_class(handler)
 
     if status_printer:
         print('ok')
-        @state.vehicle.message_listener('STATUSTEXT')
+        @vehicle.message_listener('STATUSTEXT')
         def listener(self, name, m):
             status_printer(re.sub(r'(^|\n)', '>>> ', m.text.rstrip()))
     
-    state.prepare(await_params=await_params, rate=rate)
-    return state.vehicle
+    vehicle.initialize(await_params=await_params, rate=rate)
+    return vehicle

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -348,8 +348,11 @@ class MPFakeState:
         for fn in self.message_listeners.get('*', []):
             fn(self, typ, m)
 
-        if self.vehicle.mavrx_callback:
-            self.vehicle.mavrx_callback(m)
+        # Downstream.
+        for fn in self.vehicle.message_listeners.get(typ, []):
+            fn(self.vehicle, typ, m)
+        for fn in self.vehicle.message_listeners.get('*', []):
+            fn(self.vehicle, typ, m)
 
     def prepare(self, await_params=False, rate=None):
         # errprinter('Await heartbeat.')

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -81,7 +81,7 @@ class MAVHandler:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after read timeout')
-                                if self.master.reset:
+                                if hasattr(self.master, 'reset'):
                                     self.master.reset()
                                 else:
                                     try:
@@ -105,7 +105,7 @@ class MAVHandler:
                         except socket.error as error:
                             if error.errno == ECONNABORTED:
                                 errprinter('reestablishing connection after send timeout')
-                                if self.master.reset:
+                                if hasattr(self.master, 'reset'):
                                     self.master.reset()
                                 else:
                                     try:
@@ -118,7 +118,7 @@ class MAVHandler:
                             # If connection reset (closed), stop polling.
                             return
                         except Exception as e:
-                            # TODO this should be more rigious. How to avoid
+                            # TODO this should be more rigorous. How to avoid
                             #   invalid MAVLink prefix '73'
                             #   invalid MAVLink prefix '13'
                             # errprinter('mav recv error:', e)

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -282,7 +282,7 @@ class HasObservers(object):
         .. code:: python
 
             #Callback to print the location in global and local frames
-            def location_callback(vehicle, location):
+            def location_callback(vehicle, attr_name):
                 print "Location (Global): ", vehicle.location.global_frame
                 print "Location (Local): ", vehicle.location.local_frame
 

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -792,52 +792,6 @@ class Vehicle(HasObservers):
         """
         return self._parameters
 
-    def unset_mavlink_callback(self):
-        """
-        Clears the asynchronous notification added by :py:func:`set_mavlink_callback <dronekit.lib.Vehicle.set_mavlink_callback>`.
-
-        The code snippet below shows how to set, then clear, a MAVLink callback function.
-
-        .. code:: python
-
-            # Set MAVLink callback handler (after getting Vehicle instance)
-            vehicle.set_mavlink_callback(mavrx_debug_handler)
-
-            # Remove the MAVLink callback handler. Callback will not be
-            # called after this point.
-            vehicle.unset_mavlink_callback()
-        """
-        self.mavrx_callback = None
-
-    def set_mavlink_callback(self, callback):
-        """
-        Provides asynchronous notification when any MAVLink packet is received by this vehicle.
-
-        Only a single callback can be set. :py:func:`unset_mavlink_callback <dronekit.lib.Vehicle.unset_mavlink_callback>` removes the callback.
-
-        .. tip::
-
-            This method is implemented - but we hope you don't need it.
-
-            Because of the asynchronous attribute/waypoint/parameter notifications there should be no need for
-            API clients to see raw MAVLink.  Please provide feedback if we missed a use-case.
-
-        The code snippet below shows how to set a "demo" callback function as the callback handler:
-
-        .. code:: python
-
-            # Demo callback handler for raw MAVLink messages
-            def mavrx_debug_handler(message):
-                print "Received", message
-
-            # Set MAVLink callback handler (after getting Vehicle instance)
-            vehicle.set_mavlink_callback(mavrx_debug_handler)
-
-        :param callback: The callback function to be invoked when a raw MAVLink message is received.
-
-        """
-        self.mavrx_callback = callback
-
     def send_mavlink(self, message):
         """
         This method is used to send raw MAVLink "custom messages" to the vehicle.

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -15,10 +15,9 @@ The code snippet below shows how to use :py:func:`connect` to obtain an instance
 .. code:: python
 
     from dronekit import connect
-    
+
     # Connect to the Vehicle using "connection string" (in this case an address on network)
     vehicle = connect('127.0.0.1:14550', await_params=True)
-
 
 :py:class:`Vehicle <dronekit.lib.Vehicle>` provides access to vehicle *state* through python attributes
 (e.g. :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>`)
@@ -33,14 +32,12 @@ Asynchronous notification on vehicle attribute changes is available by registeri
   (:py:func:`Vehicle.send_mavlink <dronekit.lib.Vehicle.send_mavlink>`, :py:func:`Vehicle.message_factory <dronekit.lib.Vehicle.message_factory>`).
 * Missions are downloaded and uploaded through the :py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>` attribute
   (see :py:class:`CommandSequence <dronekit.lib.CommandSequence>` for more information).
-  
+
 A number of other useful classes and methods are listed below.
 
 ----
 
 .. todo:: Update this when have confirmed how to register for parameter notifications.
-
-
 
 .. py:function:: connect(ip, await_params=False, status_printer=errprinter, vehicle_class=Vehicle, rate=4)
 
@@ -52,13 +49,13 @@ A number of other useful classes and methods are listed below.
     :param status_printer: NA    
     :param Vehicle vehicle_class: NA     
     :param int rate: NA
-    
+
     :returns: A connected :py:class:`Vehicle` object.
 
 ----
-    
+
     .. todo:: Confirm what status_printer, vehicle_class and rate "mean". Can we hide in API. Can we get method defined in this file.
-    
+
 """
 
 local_path = ''
@@ -121,7 +118,7 @@ class LocationGlobal(object):
         self.lon = lon
         self.alt = alt
         self.is_relative = is_relative
-        
+
         # This is for backward compatibility.
         self.local_frame = None
         self.global_fame = None
@@ -135,9 +132,9 @@ Location = LocationGlobal
 class LocationLocal(object):
     """
     A local location object.
-    
+
     The north, east and down are relative to the EKF origin.  This is most likely the location where the vehicle was turned on.  
-    
+
     :param north: Position north of the EKF origin in meters.
     :param east: Position east of the EKF origin in meters.
     :param down: Position down from the EKF origin in meters. (i.e. negative altitude in meters)
@@ -146,7 +143,7 @@ class LocationLocal(object):
         self.north = north
         self.east = east
         self.down = down
-        
+
     def __str__(self):
         return "LocationLocal:north=%s,east=%s,down=%s" % (self.north, self.east, self.down)
 
@@ -172,7 +169,6 @@ class GPSInfo(object):
     def __str__(self):
         return "GPSInfo:fix=%s,num_sat=%s" % (self.fix_type, self.satellites_visible)
 
-
 class Battery(object):
     """
     System battery information.
@@ -195,7 +191,6 @@ class Battery(object):
     def __str__(self):
         return "Battery:voltage={},current={},level={}".format(self.voltage, self.current, self.level)
 
-
 class Rangefinder(object):
     """
     Rangefinder readings.
@@ -209,7 +204,6 @@ class Rangefinder(object):
 
     def __str__(self):
         return "Rangefinder: distance={}, voltage={}".format(self.distance, self.voltage)
-
 
 class VehicleMode(object):
     """
@@ -239,7 +233,6 @@ class VehicleMode(object):
             print "Vehicle Mode", vehicle.mode
 
         vehicle.on_attribute('mode', mode_callback)
-
 
     The code snippet below shows how to change the vehicle mode to AUTO:
 
@@ -283,7 +276,7 @@ class HasObservers(object):
         The listener callback function is called with the ``vehicle`` and ``attr_name`` arguments.
         This can be used to infer the related attribute if the same callback is used 
         for watching several attributes.
-        
+
         The example below shows how to get callbacks for location changes:
 
         .. code:: python
@@ -295,7 +288,7 @@ class HasObservers(object):
 
             #Add observer for the vehicle's current location
             vehicle.on_attribute('location', location_callback)
-            
+
         .. note::
             Attribute changes will only be published for changes due to some other entity.
             They will not be published for changes made by the local API client
@@ -303,7 +296,6 @@ class HasObservers(object):
 
         :param attr_name: The attribute to watch.
         :param observer: The callback to invoke when a change in the attribute is detected.
-
 
         """
         l = self.__observers.get(attr_name)
@@ -323,10 +315,8 @@ class HasObservers(object):
 
             vehicle.remove_attribute_listener('global_frame', location_callback)
 
-
         :param attr_name: The attribute name that is to have an observer removed.
         :param observer: The callback function to remove.
-
 
         """
         l = self.__observers.get(attr_name)
@@ -390,26 +380,21 @@ class Vehicle(HasObservers):
 
         Current :py:class:`LocationGlobal`.
 
-
     .. py:attribute:: location.local_frame
 
         Current :py:class:`LocationLocal`.
-
 
     .. py:attribute:: attitude
 
         Current vehicle :py:class:`Attitude` (pitch, yaw, roll).
 
-
     .. py:attribute:: velocity
 
         Current velocity as a three element list ``[ vx, vy, vz ]`` (in meter/sec).
 
-
     .. py:attribute:: mode
 
         This attribute is used to get and set the current flight mode (:py:class:`VehicleMode`).
-
 
     .. py:attribute:: airspeed
 
@@ -424,7 +409,6 @@ class Vehicle(HasObservers):
     .. py:attribute:: gps_0
 
         GPS position information (:py:class:`GPSInfo`).
-
 
     .. py:attribute:: armed
 
@@ -443,23 +427,19 @@ class Vehicle(HasObservers):
             # Arm the vehicle
             vehicle.armed = True
 
-
     .. py:attribute:: mount_status
 
         Current status of the camera mount (gimbal) as a three element list: ``[ pitch, yaw, roll ]``.
 
         The values in the list are set to ``None`` if no mount is configured.
 
-
     .. py:attribute:: battery
 
         Current system :py:class:`Battery` status.
 
-
     .. py:attribute:: rangefinder
 
         :py:class:`Rangefinder` distance and voltage values.
-
 
     .. py:attribute:: channel_override
 
@@ -497,11 +477,9 @@ class Vehicle(HasObservers):
             # Cancel override on channel 1 and 4 by sending 0
             vehicle.channel_override = { "1" : 0, "4" : 0 }
 
-
         .. versionchanged:: 1.0
 
             This update replaces ``rc_override`` with ``channel_override``/``channel_readback`` documentation.
-
 
         .. todo:: Add note to the examples/guide like warning above not to use this mechanism except as intended:
 
@@ -525,7 +503,6 @@ class Vehicle(HasObservers):
             * how to address the units issue?  Merely with documentation or some other way?
             * is there any benefit of using lists rather than tuples for these attributes
 
-
     .. py:attribute:: channel_readback
 
         This read-only attribute returns a dictionary containing the *original* vehicle RC channel values (ignoring any overrides set using
@@ -536,8 +513,6 @@ class Vehicle(HasObservers):
         .. code:: python
 
             RC readback: {'1': 1500, '3': 1000, '2': 1500, '5': 1800, '4': 1500, '7': 1000, '6': 1000, '8': 1800} ? Dictionary () (read only)
-
-
 
     .. todo:: In V2, there may be ardupilot specific attributes & types (as in the introduction). If so, text below might be useful.
 
@@ -550,7 +525,6 @@ class Vehicle(HasObservers):
         .. py:attribute:: ap_pin5_value
 
             ? double (0, 1, 2.3 etc...)
-
 
     .. todo:: Add waypoint_home attribute IF this is added: https://github.com/dronekit/dronekit-python/issues/105
 
@@ -582,7 +556,7 @@ class Vehicle(HasObservers):
         self._vx = None
         self._vy = None
         self._vz = None
-        
+
         @self.message_listener('GLOBAL_POSITION_INT')
         def listener(self, name, m):
             (self._lat, self._lon) = (m.lat / 1.0e7, m.lon / 1.0e7)
@@ -607,7 +581,7 @@ class Vehicle(HasObservers):
         self._pitchspeed = None
         self._yawspeed = None
         self._rollspeed = None
-        
+
         @self.message_listener('ATTITUDE')
         def listener(self, name, m):
             self._pitch = m.pitch
@@ -622,7 +596,7 @@ class Vehicle(HasObservers):
         self._alt = None
         self._airspeed = None
         self._groundspeed = None
-        
+
         @self.message_listener('VFR_HUD')
         def listener(self, name, m):
             self._heading = m.heading
@@ -675,7 +649,7 @@ class Vehicle(HasObservers):
         self._voltage = None
         self._current = None
         self._level = None
-        
+
         @self.message_listener('SYS_STATUS')
         def listener(self, name, m):
             self._voltage = m.voltage_battery
@@ -687,7 +661,7 @@ class Vehicle(HasObservers):
         self._epv = None
         self._satellites_visible = None
         self._fix_type = None  # FIXME support multiple GPSs per vehicle - possibly by using componentId
-        
+
         @self.message_listener('GPS_RAW_INT')
         def listener(self, name, m):
             self._eph = m.eph
@@ -700,7 +674,7 @@ class Vehicle(HasObservers):
 
         @self.message_listener(['WAYPOINT_CURRENT', 'MISSION_CURRENT'])
         def listener(self, name, m):
-            self._last_waypoint = m.seq
+            self._last_waypoint = max(m.seq - 1, 0)
 
         self._ekf_poshorizabs = False
         self._ekf_constposmode = False
@@ -770,7 +744,7 @@ class Vehicle(HasObservers):
                 handler.fix_targets(wp)
                 self._master.mav.send(wp)
                 self._wp_uploaded[msg.seq] = True
-        
+
         # TODO: Waypoint loop listeners
 
         # Parameters.
@@ -831,7 +805,7 @@ class Vehicle(HasObservers):
                 traceback.print_exc()
 
         # Heartbeats.
-        
+
         self._heartbeat_started = False
         self._heartbeat_lastsent = 0
         self._heartbeat_lastreceived = 0
@@ -908,20 +882,12 @@ class Vehicle(HasObservers):
 
         After the return from ``flush()`` any writes are guaranteed to have completed (or thrown an
         exception) and future reads will see their effects.
-        
+
         .. warning:: 
-        
+
             This has been replaced by :py:func:`Vehicle.commands.upload() <Vehicle.commands.upload>`.
         """
-        if self._wpts_dirty:
-            self._master.waypoint_clear_all_send()
-            if self._wploader.count() > 0:
-                self._wp_uploaded = [False]*self._wploader.count()
-                self._master.waypoint_count_send(self._wploader.count())
-                while False in self._wp_uploaded:
-                    time.sleep(0.1)
-                self._wp_uploaded = None
-            self._wpts_dirty = False
+        return self.commands.upload()
 
     #
     # Private sugar methods
@@ -1034,12 +1000,12 @@ class Vehicle(HasObservers):
     def home_location(self):
         """
         The current home location in a :py:class:`LocationGlobal`. 
-        
+
         This value is initially set by the autopilot as the location of first GPS Lock.
         The attribute has a value of ``None`` until :py:func:`Vehicle.commands` has been downloaded. 
         If the attribute is queried before the home location is set the returned `LocationGlobal` 
         will have zero values for its member attributes.
-        
+
         .. code-block:: python
 
             #Connect to a vehicle object (for example, on com14)
@@ -1048,25 +1014,25 @@ class Vehicle(HasObservers):
             # Download the vehicle waypoints (commands). Wait until download is complete.
             cmds = vehicle.commands
             cmds.download()
-            cmds.wait_valid()
-            
+            cmds.wait_ready()
+
             # Get the home location
             home = vehicle.home_location
-            
+
         The attribute is not writeable or observable.
-        
+
         """
-        loc = self.__module.wploader.wp(0)
+        loc = self._wploader.wp(0)
         if loc:
             return LocationGlobal(loc.x, loc.y, loc.z, is_relative=False)
-    
+
     @home_location.setter
     def home_location(self, pos):
         """
         Sets the home location to that of a ``LocationGlobal`` object.
 
         .. note:: 
-        
+
             If the GPS values differ heavily from EKF values, setting this value will fail silently.
         """
         self.send_mavlink(self.message_factory.command_long_encode(
@@ -1215,7 +1181,6 @@ class Parameters(HasObservers):
         # Change the parameter value to something different.
         vehicle.parameters['THR_MIN']=100
 
-
     .. note::
 
         At time of writing ``Parameters`` does not implement the observer methods, and change notification for parameters
@@ -1261,7 +1226,7 @@ class Parameters(HasObservers):
                 if name in self._vehicle._params_map and self._vehicle._params_map[name] == value:
                     return True
                 time.sleep(0.1)
-        
+
         if retries > 0:
             errprinter("timeout setting parameter %s to %f" % (name, value))
         return False
@@ -1285,7 +1250,6 @@ class Command(mavutil.mavlink.MAVLink_mission_item_message):
 
         cmd = Command(0,0,0, mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
             mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 0, 0, 0, 0,-34.364114, 149.166022, 30)
-
 
     :param target_system: The id number of the message's target system (drone, GSC) within the MAVLink network.
         Set this to zero (broadcast) when communicating with a companion computer.
@@ -1322,8 +1286,7 @@ class CommandSequence(object):
 
     The current commands/mission for a vehicle are accessed using the :py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>` attribute.
     Waypoints are not downloaded from vehicle until :py:func:`download()` is called.  The download is asynchronous;
-    use :py:func:`wait_ready()` to block your thread until the download is complete.
-
+    use :py:func:`wait_valid()` to block your thread until the download is complete.
     The code to download the commands from a vehicle is shown below:
 
     .. code-block:: python
@@ -1335,13 +1298,12 @@ class CommandSequence(object):
         # Download the vehicle waypoints (commands). Wait until download is complete.
         cmds = vehicle.commands
         cmds.download()
-        cmds.wait_ready()
+        cmds.wait_valid()
 
     The set of commands can be changed and uploaded to the client. The changes are not guaranteed to be complete until
     :py:func:`upload() <Vehicle.commands.upload>` is called.
 
     .. code:: python
-
         cmds = vehicle.commands
         cmds.clear()
         lat = -34.364114,
@@ -1380,8 +1342,7 @@ class CommandSequence(object):
     def download(self):
         '''
         Download all waypoints from the vehicle.
-
-        The download is asynchronous. Use :py:func:`wait_ready()` to block your thread until the download is complete.
+        The download is asynchronous. Use :py:func:`wait_valid()` to block your thread until the download is complete.
         '''
         self.wait_ready()
         self._vehicle._ready_attrs.remove('commands')
@@ -1437,23 +1398,28 @@ class CommandSequence(object):
     def clear(self):
         '''
         Clear the command list. 
-        
+
         This command will be sent to the vehicleonly after you call :py:func:`upload() <Vehicle.commands.upload>`.
         '''
+
+        # Add home point again.
         self.wait_ready()
+        home = self._vehicle._wploader.wp(0)
         self._vehicle._wploader.clear()
+        if home:
+            self._vehicle._wploader.add(home, comment='Added by DroneKit')
         self._vehicle._wpts_dirty = True
 
     def add(self, cmd):
         '''
         Add a new command (waypoint) at the end of the command list.
-        
-        .. note:: Commands are sent to the vehicle only after you call ::py:func:`upload() <Vehicle.commands.upload>`.
 
+        .. note:: Commands are sent to the vehicle only after you call ::py:func:`upload() <Vehicle.commands.upload>`.
         :param Command cmd: The command to be added.
         '''
         self.wait_ready()
-        self._vehicle._wploader.add(cmd, comment = 'Added by DroneAPI')
+        self._vehicle._handler.fix_targets(cmd)
+        self._vehicle._wploader.add(cmd, comment='Added by DroneKit')
         self._vehicle._wpts_dirty = True
 
     def upload(self):
@@ -1463,9 +1429,15 @@ class CommandSequence(object):
         After the return from ``upload()`` any writes are guaranteed to have completed (or thrown an
         exception) and future reads will see their effects.
         """
-        if self.__module.vehicle.wpts_dirty:
-            self.__module.send_all_waypoints()
-            self.__module.vehicle.wpts_dirty = False
+        if self._vehicle._wpts_dirty:
+            self._vehicle._master.waypoint_clear_all_send()
+            if self._vehicle._wploader.count() > 0:
+                self._vehicle._wp_uploaded = [False]*self._vehicle._wploader.count()
+                self._vehicle._master.waypoint_count_send(self._vehicle._wploader.count())
+                while False in self._vehicle._wp_uploaded:
+                    time.sleep(0.1)
+                self._vehicle._wp_uploaded = None
+            self._vehicle._wpts_dirty = False
 
     @property
     def count(self):
@@ -1474,7 +1446,7 @@ class CommandSequence(object):
 
         :return: The number of waypoints in the sequence.
         '''
-        return self._vehicle._wploader.count()
+        return max(self._vehicle._wploader.count() - 1, 0)
 
     @property
     def next(self):
@@ -1488,7 +1460,7 @@ class CommandSequence(object):
         """
         Set a new ``next`` waypoint for the vehicle.
         """
-        self._vehicle._master.waypoint_set_current_send(index)
+        self._vehicle._master.waypoint_set_current_send(index + 1)
 
     def __len__(self):
         '''
@@ -1496,11 +1468,19 @@ class CommandSequence(object):
 
         :return: The number of waypoints in the sequence.
         '''
-        return self._vehicle._wploader.count()
+        return max(self._vehicle._wploader.count() - 1, 0)
 
     def __getitem__(self, index):
-        return self._vehicle._wploader.wp(index)
+        if isinstance(index, slice):
+            return [self[ii] for ii in xrange(*index.indices(len(self)))]
+        elif isinstance(index, int):
+            item = self._vehicle._wploader.wp(index + 1)
+            if not item:
+                raise IndexError('Index %s out of range.' % index)
+            return item
+        else:
+            raise TypeError('Invalid argument type.')
 
     def __setitem__(self, index, value):
-        self._vehicle._wploader.set(value, index)
+        self._vehicle._wploader.set(value, index + 1)
         self._vehicle._wpts_dirty = True

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -563,6 +563,29 @@ class Vehicle(HasObservers):
         self._waypoints = CommandSequence(self.__module)
         self.wpts_dirty = False
 
+        # Attaches message listeners.
+        self.message_listeners = dict()
+
+    def on_message(self, name, fn):
+        """
+        Adds a message listener.
+        """
+        name = str(name)
+        if name not in self.message_listeners:
+            self.message_listeners[name] = []
+        if fn not in self.message_listeners[name]:
+            self.message_listeners[name].append(fn)
+
+    def remove_message_listener(self, name, fn):
+        """
+        Removes a message listener.
+        """
+        name = str(name)
+        if name in self.message_listeners:
+            self.message_listeners[name].remove(fn)
+            if len(self.message_listeners[name]) == 0:
+                del self.message_listeners[name]
+
     def close(self):
         """
         Call ``Vehicle.close()`` before exiting scripts to ensure that all messages have been uploaded/sent:
@@ -877,11 +900,6 @@ class Vehicle(HasObservers):
 
             time.sleep(pollinterval)
         raise APIException("Vehicle did not complete initialization")
-
-    def on_message(self, name, fn):
-        def handler(state, name, m):
-            return fn(self, name, m)
-        return self.__module.on_message(name, handler)
 
 class Parameters(HasObservers):
     """

--- a/dronekit/tools/__init__.py
+++ b/dronekit/tools/__init__.py
@@ -1,23 +1,30 @@
+from __future__ import print_function
 import os
-from nose.tools import assert_equals, with_setup
+import sys
 from dronekit_sitl import SITL
 
-sitl = SITL('copter', '3.3-rc5')
+sitl = None
 sitl_args = ['-I0', '--model', 'quad', '--home=-35.363261,149.165230,584,353']
 
 if 'SITL_SPEEDUP' in os.environ:
-	sitl_args += ['--speedup', str(os.environ['SITL_SPEEDUP'])]
+    sitl_args += ['--speedup', str(os.environ['SITL_SPEEDUP'])]
 if 'SITL_RATE' in os.environ:
-	sitl_args += ['-r', str(os.environ['SITL_RATE'])]
+    sitl_args += ['-r', str(os.environ['SITL_RATE'])]
 
 def setup_sitl():
+    global sitl
+    sitl = SITL('copter', '3.3-rc5')
     sitl.launch(sitl_args, await_ready=True, restart=True)
 
 def teardown_sitl():
     sitl.stop()
 
 def with_sitl(fn):
+    from nose.tools import assert_equals, with_setup
     @with_setup(setup_sitl, teardown_sitl)
     def test(*args, **kargs):
         return fn('tcp:127.0.0.1:5760', *args, **kargs)
     return test
+
+def errprinter(*args):
+    print(*args, file=sys.stderr)

--- a/examples/flight_replay/flight_replay.py
+++ b/examples/flight_replay/flight_replay.py
@@ -111,7 +111,7 @@ def replay_mission(payload):
 
 # Now download the vehicle waypoints
 cmds = vehicle.commands
-cmds.wait_valid()
+cmds.wait_ready()
 mission_id = int(args.mission_id)
 max_freq = 0.1
 json = download_messages(mission_id, max_freq)

--- a/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
+++ b/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
@@ -611,8 +611,8 @@ set_home(vehicle.location.global_frame)
 print "Get new home location" #This reloads the home location in GCSs
 cmds = vehicle.commands
 cmds.download()
-cmds.wait_valid()
-print " Home Location: %s" % vehicle.home_location
+cmds.wait_ready()
+print " Home WP: %s" % cmds[0]
 
 print("Velocity South and West")
 send_global_velocity(NORTH,EAST,0)

--- a/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
+++ b/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
@@ -612,7 +612,7 @@ print "Get new home location" #This reloads the home location in GCSs
 cmds = vehicle.commands
 cmds.download()
 cmds.wait_ready()
-print " Home WP: %s" % cmds[0]
+print " Home Location: %s" % vehicle.home_location
 
 print("Velocity South and West")
 send_global_velocity(NORTH,EAST,0)

--- a/examples/mission_basic/mission_basic.py
+++ b/examples/mission_basic/mission_basic.py
@@ -78,22 +78,6 @@ def distance_to_current_waypoint():
     return distancetopoint
 
 
-def clear_mission():
-    """
-    Clear the current mission.
-    """
-    cmds = vehicle.commands
-    vehicle.commands.clear()
-    vehicle.flush()
-
-    # After clearing the mission you MUST re-download the mission from the vehicle 
-    # before vehicle.commands can be used again
-    # (see https://github.com/dronekit/dronekit-python/issues/230)
-    cmds = vehicle.commands
-    cmds.download()
-    cmds.wait_ready()
-    
-
 def download_mission():
     """
     Download the current mission from the vehicle.

--- a/examples/mission_basic/mission_basic.py
+++ b/examples/mission_basic/mission_basic.py
@@ -76,6 +76,22 @@ def distance_to_current_waypoint():
     targetWaypointLocation=LocationGlobal(lat,lon,alt,is_relative=True)
     distancetopoint = get_distance_metres(vehicle.location.global_frame, targetWaypointLocation)
     return distancetopoint
+
+
+def clear_mission():
+    """
+    Clear the current mission.
+    """
+    cmds = vehicle.commands
+    vehicle.commands.clear()
+    vehicle.flush()
+
+    # After clearing the mission you MUST re-download the mission from the vehicle 
+    # before vehicle.commands can be used again
+    # (see https://github.com/dronekit/dronekit-python/issues/230)
+    cmds = vehicle.commands
+    cmds.download()
+    cmds.wait_ready()
     
 
 def download_mission():
@@ -84,7 +100,7 @@ def download_mission():
     """
     cmds = vehicle.commands
     cmds.download()
-    cmds.wait_valid() # wait until download is complete.
+    cmds.wait_ready() # wait until download is complete.
 
 
 

--- a/examples/mission_import_export/mission_import_export.py
+++ b/examples/mission_import_export/mission_import_export.py
@@ -71,8 +71,14 @@ def upload_mission(aFileName):
     #Clear existing mission from vehicle
     print ' Clear mission'
     cmds = vehicle.commands
+    cmds.download()
+    cmds.wait_ready()
     cmds.clear()
-    #Add new mission to vehicle
+    vehicle.flush()
+    print 'ClearCount: %s' % cmds.count
+    #add new mission
+    cmds.download()
+    cmds.wait_ready()
     for command in missionlist:
         cmds.add(command)
     print ' Upload mission'
@@ -88,8 +94,8 @@ def download_mission():
     missionlist=[]
     cmds = vehicle.commands
     cmds.download()
-    cmds.wait_valid()
-    for cmd in cmds:  
+    cmds.wait_ready()
+    for cmd in cmds[1:]:  #skip first item as it is home waypoint.
         missionlist.append(cmd)
     return missionlist
 

--- a/examples/mission_import_export/mission_import_export.py
+++ b/examples/mission_import_export/mission_import_export.py
@@ -71,14 +71,8 @@ def upload_mission(aFileName):
     #Clear existing mission from vehicle
     print ' Clear mission'
     cmds = vehicle.commands
-    cmds.download()
-    cmds.wait_ready()
     cmds.clear()
-    vehicle.flush()
-    print 'ClearCount: %s' % cmds.count
-    #add new mission
-    cmds.download()
-    cmds.wait_ready()
+    #Add new mission to vehicle
     for command in missionlist:
         cmds.add(command)
     print ' Upload mission'
@@ -94,8 +88,8 @@ def download_mission():
     missionlist=[]
     cmds = vehicle.commands
     cmds.download()
-    cmds.wait_ready()
-    for cmd in cmds[1:]:  #skip first item as it is home waypoint.
+    cmds.wait_valid()
+    for cmd in cmds:  
         missionlist.append(cmd)
     return missionlist
 
@@ -151,4 +145,3 @@ print "\nShow original and uploaded/downloaded files:"
 printfile(import_mission_filename)
 #Print exported file (for demo purposes only)
 printfile(export_mission_filename)
-

--- a/examples/perf/perf_test.py
+++ b/examples/perf/perf_test.py
@@ -228,7 +228,7 @@ vehicle.set_mavlink_callback(mavrx_debug_handler)
 # Now download the vehicle waypoints
 cmds = vehicle.commands
 cmds.download()
-cmds.wait_valid()
+cmds.wait_ready()
 print "Home WP: %s" % cmds[0]
 print "Current dest: %s" % cmds.next
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -55,7 +55,7 @@ print "\n Home Location (before downloading waypoints): %s" % vehicle.home_locat
 
 cmds = vehicle.commands
 cmds.download()
-cmds.wait_valid()
+cmds.wait_ready()
 print " Home Location (after downloading waypoints): %s" % vehicle.home_location
 
 
@@ -95,14 +95,6 @@ time.sleep(2)
 
 # Remove observer - specifying the attribute and previously registered callback function
 vehicle.remove_attribute_observer('mode', mode_callback)
-
-
-# Get Vehicle Home location ((0 index in Vehicle.commands)
-print "\nGet home location" 
-cmds = vehicle.commands
-cmds.download()
-cmds.wait_ready()
-print " Home WP: %s" % cmds[0]
 
 
 # Get/Set Vehicle Parameters

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -97,6 +97,14 @@ time.sleep(2)
 vehicle.remove_attribute_observer('mode', mode_callback)
 
 
+# Get Vehicle Home location ((0 index in Vehicle.commands)
+print "\nGet home location" 
+cmds = vehicle.commands
+cmds.download()
+cmds.wait_ready()
+print " Home WP: %s" % cmds[0]
+
+
 # Get/Set Vehicle Parameters
 print "\nRead vehicle param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
 print "Write vehicle param 'THR_MIN' : 10"

--- a/tests/sitl/test_110.py
+++ b/tests/sitl/test_110.py
@@ -24,17 +24,17 @@ def test_110(connpath):
     time.sleep(3)
 
     # Define example callback for mode
-    def armed_callback(attribute):
+    def armed_callback(vehicle, attribute):
         armed_callback.called += 1
     armed_callback.called = 0
 
-    # When the same (event, callback) pair is passed to add_attribute_observer,
+    # When the same (event, callback) pair is passed to on_attribute,
     # only one instance of the observer callback should be added.
-    v.add_attribute_observer('armed', armed_callback)
-    v.add_attribute_observer('armed', armed_callback)
-    v.add_attribute_observer('armed', armed_callback)
-    v.add_attribute_observer('armed', armed_callback)
-    v.add_attribute_observer('armed', armed_callback)
+    v.on_attribute('armed', armed_callback)
+    v.on_attribute('armed', armed_callback)
+    v.on_attribute('armed', armed_callback)
+    v.on_attribute('armed', armed_callback)
+    v.on_attribute('armed', armed_callback)
 
     # Disarm and see update.
     v.armed = False
@@ -44,13 +44,13 @@ def test_110(connpath):
     # Ensure the callback was called.
     assert armed_callback.called > 0, "Callback should have been called."
 
-    # Rmove all observers. The first call should remove all listeners
+    # Rmove all listeners. The first call should remove all listeners
     # we've added; the second call should be ignored and not throw.
     # NOTE: We test if armed_callback were treating adding each additional callback
-    # and remove_attribute_observer were removing them one at a time; in this
+    # and remove_attribute_listener were removing them one at a time; in this
     # case, there would be three callbacks still attached.
-    v.remove_attribute_observer('armed', armed_callback)
-    v.remove_attribute_observer('armed', armed_callback)
+    v.remove_attribute_listener('armed', armed_callback)
+    v.remove_attribute_listener('armed', armed_callback)
     callcount = armed_callback.called
 
     # Re-arm and see update.

--- a/tests/sitl/test_115.py
+++ b/tests/sitl/test_115.py
@@ -15,7 +15,7 @@ def test_115(connpath):
     mavlink_callback.count = 0
 
     # Set the callback.
-    v.set_mavlink_callback(mavlink_callback)
+    v.on_message('*', mavlink_callback)
 
     # Change the vehicle into STABILIZE mode
     v.mode = VehicleMode("STABILIZE")
@@ -26,7 +26,7 @@ def test_115(connpath):
     assert mavlink_callback.count > 0
 
     # Unset the callback.
-    v.unset_mavlink_callback()
+    v.remove_message_listener('*', mavlink_callback)
     savecount = mavlink_callback.count
 
     # Disarm. A callback of None should not throw errors

--- a/tests/sitl/test_waypoints.py
+++ b/tests/sitl/test_waypoints.py
@@ -48,20 +48,17 @@ def test_parameter(connpath):
     time.sleep(10)
 
     # Initial
-    vehicle.commands.download()
-    vehicle.commands.wait_valid()
-    assert_equals(len(vehicle.commands), 0)
-    assert_not_equals(vehicle.home_location, None)
-
-    # Save home for comparison.
-    home = vehicle.home_location
+    cmds = vehicle.commands
+    cmds.download()
+    cmds.wait_ready()
+    assert_equals(len(cmds), 1)
 
     # After clearing
-    vehicle.commands.clear()
-    vehicle.commands.upload()
-    vehicle.commands.download()
-    vehicle.commands.wait_valid()
-    assert_equals(len(vehicle.commands), 0)
+    cmds.clear()
+    vehicle.flush()
+    cmds.download()
+    cmds.wait_ready()
+    assert_equals(len(cmds), 1)
 
     # Upload
     for command in [
@@ -78,33 +75,6 @@ def test_parameter(connpath):
     vehicle.commands.upload()
 
     # After upload
-    vehicle.commands.download()
-    vehicle.commands.wait_valid()
-    assert_equals(len(vehicle.commands), 8)
-
-    # Test iteration.
-    count = 0
-    for cmd in vehicle.commands:
-        assert_not_equals(cmd, None)
-        count += 1
-    assert_equals(count, 8)
-
-    # Test slicing
-    count = 3
-    for cmd in vehicle.commands[2:5]:
-        assert_not_equals(cmd, None)
-        assert_equals(cmd.seq, count)
-        count += 1
-    assert_equals(count, 6)
-
-    # Test next property
-    assert_equals(vehicle.commands.next, 0)
-    vehicle.commands.next = 3
-    while vehicle.commands.next != 3:
-        time.sleep(0.1)
-    assert_equals(vehicle.commands.next, 3)
-
-    # Home should be preserved
-    assert_equals(home.lat, vehicle.home_location.lat)
-    assert_equals(home.lon, vehicle.home_location.lon)
-    assert_equals(home.alt, vehicle.home_location.alt)
+    cmds.download()
+    cmds.wait_ready()
+    assert_equals(len(cmds), 9)


### PR DESCRIPTION
This is a pretty heavy PR, but also the last major refactor I have planned.

Rather than obtusely split parameter logic between a MAVLink handler and a Vehicle object, the Vehicle object (through "message" handlers and "event loop" handlers) now implements all of its own core logic inside the class. There is still some slightly awkward coupling going on between the classes, but there's far less of it, and the code to manage properties is all in one place.

As a side effect of this, we're now able to track the status of most attributes, and as such have a working `wait_ready` implementation on the vehicle that serves as the basis for `await_param` (which should be deprecated and replaced) as well as other methods like `wait_valid`, etc.

Additionally, we get rid of the MAVLink rx handlers and only expose the `on_message` primitive, which acts as our MAVLink interaction story. Ideally, we can abstract the message contruction story as well, though I haven't put much thought into it.