### PR TITLE
Adds Parameters.get function.

### DIFF
--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -1203,6 +1203,11 @@ class Parameters(HasObservers):
         self.wait_ready()
         self.set(name, value)
 
+    def get(self, name, wait_ready=True):
+        if wait_ready:
+            self.wait_ready()
+        return self._vehicle._params_map.get(name, None)
+
     def set(self, name, value, retries=3, wait_ready=False):
         if wait_ready:
             self.wait_ready()

--- a/tests/sitl/test_parameters.py
+++ b/tests/sitl/test_parameters.py
@@ -1,0 +1,24 @@
+import time
+import sys
+import os
+from dronekit import connect, VehicleMode
+from dronekit.tools import with_sitl
+from nose.tools import assert_equals, assert_not_equals
+
+@with_sitl
+def test_parameters(connpath):
+    vehicle = connect(connpath)
+
+    # When called on startup, parameter should return none.
+    assert_equals(vehicle.parameters.get('THR_MIN', wait_ready=False), None)
+
+    # With wait_ready, it should not be none.
+    assert_not_equals(vehicle.parameters.get('THR_MIN', wait_ready=True), None)
+  
+    try:
+        assert_not_equals(vehicle.parameters['THR_MIN'], None)
+    except:
+        assert False
+
+    # Garbage value after all parameters are downloaded should be None.
+    assert_equals(vehicle.parameters.get('xXx_extreme_garbage_value_xXx', wait_ready=True), None)


### PR DESCRIPTION
This is an alternative to (but maybe not replacement for) #389 to allow you to explicitly define which behavior you want on parameter lookup.

You will receive None for values that a) do not exist or b) are not downloaded yet and wait_ready=False. This will not return a KeyError, mirroring the .get() semantics of Python's dicts.