### PR TITLE
Fix GPSInfo to remove units from eph and epv definition

### DIFF
--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -153,12 +153,12 @@ class LocationLocal(object):
 
 class GPSInfo(object):
     """
-    Standard information available about GPS.
+    Standard information about GPS.
 
     If there is no GPS lock the parameters are set to ``None``.
 
-    :param IntType eph: GPS horizontal dilution of position (HDOP) in cm (m*100).
-    :param IntType epv: GPS horizontal dilution of position (VDOP) in cm (m*100).
+    :param IntType eph: GPS horizontal dilution of position (HDOP).
+    :param IntType epv: GPS horizontal dilution of position (VDOP).
     :param IntType fix_type: 0-1: no fix, 2: 2D fix, 3: 3D fix
     :param IntType satellites_visible: Number of satellites visible.
 


### PR DESCRIPTION
This fixes #412 by removing the units from the description of epv/eph. These units were copied from the MAVLINK spec for [GPS_RAW_INT](https://pixhawk.ethz.ch/mavlink/#GPS_RAW_INT) - but the spec is "wrong" because the value is unitless ... and I have confirmed that ArduPilot does return an unscaled HDOP/VDOP value.