### PR TITLE
Update attribute_observer examples and docs

### DIFF
--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -7,6 +7,11 @@ Example: Create Attribute in App
 This example shows how you can create attributes for MAVLink messages within your DroneKit-Python script and 
 use them in *in the same way* as the built-in :py:class:`Vehicle <dronekit.lib.Vehicle>` attributes.
 
+It uses the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` decorator
+to set a function that is called to process a specific message, copy its values into an attribute, and notify
+observers. An observer is then set on the new attribute using 
+:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>`.
+
 Additional information is provided in the guide topic :ref:`mavlink_messages`.
 
 .. tip::
@@ -16,7 +21,7 @@ Additional information is provided in the guide topic :ref:`mavlink_messages`.
 
     Please :ref:`contribute your code to the API <contributing_api>` so that it is available to 
     (and can be tested by) the whole DroneKit-Python community. 
-    
+
 
 
 Running the example
@@ -51,21 +56,30 @@ On the command prompt you should see (something like):
 
 .. code:: bash
 
-    RAW_IMU: time_boot_us=41270000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=1,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=41510000,xacc=0,yacc=0,zacc=-1000,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=41750000,xacc=1,yacc=0,zacc=-1000,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=41990000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=42230000,xacc=0,yacc=0,zacc=-1000,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=42470000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=42710000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=42950000,xacc=0,yacc=0,zacc=-1000,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=43190000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=1,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=43430000,xacc=0,yacc=0,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=43670000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=43910000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=0,zgyro=1,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=44150000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
-    RAW_IMU: time_boot_us=44390000,xacc=0,yacc=0,zacc=-999,xgyro=1,ygyro=1,zgyro=0,xmag=153,ymag=52,zmag=-364
-    APIThread-0 exiting...
+    Connecting to vehicle on: tcp:127.0.0.1:14550
+    >>> APM:Copter V3.3 (d6053245)
+    >>> Frame: QUAD
+    Display RAW_IMU messages for 5 seconds and then exit.
+    RAW_IMU: time_boot_us=1593318928,xacc=-3,yacc=5,zacc=-999,xgyro=0,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1593558928,xacc=-4,yacc=5,zacc=-1000,xgyro=0,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1593798928,xacc=-2,yacc=6,zacc=-1000,xgyro=1,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1594038928,xacc=-2,yacc=6,zacc=-1000,xgyro=1,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1594278928,xacc=-2,yacc=5,zacc=-999,xgyro=0,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1594518928,xacc=-2,yacc=4,zacc=-998,xgyro=1,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1594758928,xacc=-3,yacc=5,zacc=-1000,xgyro=0,ygyro=1,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1594998928,xacc=-2,yacc=4,zacc=-999,xgyro=1,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1595238928,xacc=-3,yacc=5,zacc=-1000,xgyro=0,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1595478928,xacc=-2,yacc=4,zacc=-1000,xgyro=1,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1595718928,xacc=-2,yacc=4,zacc=-999,xgyro=0,ygyro=1,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1595958928,xacc=-3,yacc=6,zacc=-1000,xgyro=0,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1596198928,xacc=-4,yacc=6,zacc=-1000,xgyro=1,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1596438928,xacc=-2,yacc=6,zacc=-1000,xgyro=0,ygyro=1,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1596678928,xacc=-3,yacc=4,zacc=-999,xgyro=1,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1596918928,xacc=-2,yacc=4,zacc=-999,xgyro=0,ygyro=1,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1597158928,xacc=-2,yacc=6,zacc=-1000,xgyro=0,ygyro=1,zgyro=1,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1597398928,xacc=-2,yacc=5,zacc=-1000,xgyro=0,ygyro=1,zgyro=0,xmag=156,ymag=41,zmag=-365
+    RAW_IMU: time_boot_us=1597638928,xacc=-3,yacc=5,zacc=-1000,xgyro=1,ygyro=0,zgyro=0,xmag=156,ymag=41,zmag=-365
+    Close vehicle object
 
 
 
@@ -116,7 +130,7 @@ representation for printing the object.
             """
             String representation of the RawIMU object
             """
-            return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc,     self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
+            return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc, self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
 
 The script should then create an instance of the class and add it as an attribute to the vehicle object retrieved from the connection.
 All values in the new attribute should be set to ``None`` so that it is obvious to users when no messages have been received. 
@@ -129,66 +143,51 @@ All values in the new attribute should be set to ``None`` so that it is obvious 
     #Create an Vehicle.raw_imu object and set all values to None.
     vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
     
-We set a callback to intercept all MAVLink messages using :py:func:`Vehicle.set_mavlink_callback() <dronekit.lib.Vehicle.set_mavlink_callback>` 
-as shown below. 
+We create a listener using the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+decorator as shown below. The listener is called for messages that contain the string "RAW_IMU", 
+with arguments for the vehicle, message name, and the message. It copies the message information into 
+the attribute and then notifies all observers.
 
 .. code:: python
 
-    def mavrx_debug_handler(message):
-        """
-        Handler for MAVLink messages.
-        """
-        #Handle raw_imu messages
-        mav_raw_imu_handler(message)
+    #Create a message listener using the decorator.   
+    @vehicle.message_listener('RAW_IMU')
+    def listener(self, name, message):
+        #Copy the message contents into the raw_imu attribute
+        self.raw_imu.time_boot_us=message.time_usec
+        self.raw_imu.xacc=message.xacc
+        self.raw_imu.yacc=message.yacc
+        self.raw_imu.zacc=message.zacc
+        self.raw_imu.xgyro=message.xgyro
+        self.raw_imu.ygyro=message.ygyro
+        self.raw_imu.zgyro=message.zgyro
+        self.raw_imu.xmag=message.xmag
+        self.raw_imu.ymag=message.ymag
+        self.raw_imu.zmag=message.zmag
+        
+        # Notify all observers of new message.
+        self._notify_attribute_listeners('raw_imu') 
 
-    # Set MAVLink callback handler (after getting Vehicle instance)
-    vehicle.set_mavlink_callback(mavrx_debug_handler)
 
-For clarity we have separated the handling code for the RAW_IMU message into ``mav_raw_imu_handler()``.  The handler simply checks the message type and 
-(for the correct messages) writes the values into the attribute. It then calls ``vehicle.notify_observers('raw_imu')`` to notify all observers of this attribute type.
-    
-.. code:: python
+.. note:: 
 
-    def mav_raw_imu_handler(message):
-        """
-        Writes received message to the (newly attached) vehicle.raw_imu object and notifies observers.
-        """
-        messagetype=str(message).split('{')[0].strip()
-        if messagetype=='RAW_IMU':
-            vehicle.raw_imu.time_boot_us=message.time_usec
-            vehicle.raw_imu.xacc=message.xacc
-            vehicle.raw_imu.yacc=message.yacc
-            vehicle.raw_imu.zacc=message.zacc
-            vehicle.raw_imu.xgyro=message.xgyro
-            vehicle.raw_imu.ygyro=message.ygyro
-            vehicle.raw_imu.zgyro=message.zgyro
-            vehicle.raw_imu.xmag=message.xmag
-            vehicle.raw_imu.ymag=message.ymag
-            vehicle.raw_imu.zmag=message.zmag
-
-           #Add Notify all observers of new message.
-            vehicle.notify_observers('raw_imu') 
+    The decorator pattern means that you can have multiple listeners for a particular message or for different
+    messages and they can all have the same function name/prototype (in this case ``listener(self, name, message``).
 
         
-At this point the ``Vehicle.raw_imu`` attribute can be treated the same as any other attribute for the duration of the session.
-You can query the attribute to get any of the values, and even add an observer as shown:
+From this point the ``Vehicle.raw_imu`` attribute can be treated the same as any other (inbuilt) attribute.
+You can query the attribute to get any of its members, and even add an observer as shown:
 
 
 .. code:: python
 
     #Callback to print the raw_imu
-    def raw_imu_callback(rawimu):
-        print vehicle.raw_imu
+    def raw_imu_callback(self, attr_name):
+        print self.raw_imu
 
 
     #Add observer for the vehicle's current location
-    vehicle.add_attribute_observer('raw_imu', raw_imu_callback)
-
-
-.. note::
-
-    It is not possible to reliably use this approach to create independent modules because only one 
-    MAVLink callback can be set at a time in the running program (``set_mavlink_callback()``) 
+    vehicle.on_attribute('raw_imu', raw_imu_callback)
 
 
 Known issues

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -56,31 +56,25 @@ On the command prompt you should see (something like):
     Accumulating vehicle attribute messages
 
     Get all vehicle attribute values:
-     Global Location: LocationGlobal:lat=-35.3632615,lon=149.1652301,alt=0.0,is_relative=False
+     Global Location: LocationGlobal:lat=-35.3632585,lon=149.165227,alt=362.0,is_relative=False
      Local Location: LocationLocal:north=None,east=None,down=None
-     Attitude: Attitude:pitch=0.00589594058692,yaw=-0.0884591862559,roll=0.000426373298978
-     Velocity: [-0.02, 0.02, 0.0]
+     Attitude: Attitude:pitch=-0.00352983362973,yaw=-0.0589601770043,roll=-0.00761049194261
+     Velocity: [0.02, -0.02, 0.0]
      GPS: GPSInfo:fix=3,num_sat=10
      Groundspeed: 0.0
      Airspeed: 0.0
      Mount status: [None, None, None]
-     Battery: Battery:voltage=12.587,current=0.0,level=99
+     Battery: Battery:voltage=12.587,current=0.0,level=98
      Rangefinder: Rangefinder: distance=None, voltage=None
      Rangefinder distance: None
      Rangefinder voltage: None
      Mode: STABILIZE
      Armed: False
-     Home Location: LocationGlobal:lat=0.0,lon=0.0,alt=0.0,is_relative=False
+     Home Location: LocationGlobal:lat=-35.3632583618,lon=149.165222168,alt=222.0,is_relative=False
 
     Set new home location
-     Waiting for home location: LocationGlobal:lat=0.0,lon=0.0,alt=0.0,is_relative=False
-     ...
-     Waiting for home location: LocationGlobal:lat=0.0,lon=0.0,alt=0.0,is_relative=False
-     Waiting for home location: LocationGlobal:lat=0.0,lon=0.0,alt=0.0,is_relative=False
+     New Home Location (altitude should be 222): LocationGlobal:lat=-35.3632583618,lon=149.165222168,alt=222.0,is_relative=False
 
-     Autopilot set home location: LocationGlobal:lat=-35.3632621765,lon=149.165237427,alt=583.989990234,is_relative=False
-     New Home Location (altitude should be 222): LocationGlobal:lat=-35.3632621765,lon=149.165237427,alt=222.0,is_relative=False
- 
     Set Vehicle.mode=GUIDED (currently: STABILIZE)
      Waiting for mode change ...
 
@@ -89,11 +83,12 @@ On the command prompt you should see (something like):
     >>> ARMING MOTORS
     >>> Initialising APM...
 
-    Add mode attribute observer for Vehicle.mode
+    Add attribute callback/observer on `vehicle` for `mode` attribute
      Set mode=STABILIZE (currently: GUIDED)
      Wait 2s so callback invoked before observer removed
-     CALLBACK: Mode changed to:  STABILIZE
-     CALLBACK: Mode changed to:  STABILIZE
+     CALLBACK: Mode changed to VehicleMode:STABILIZE
+     CALLBACK: Mode changed to VehicleMode:STABILIZE
+     Remove Vehicle.mode observer
 
     Read vehicle param 'THR_MIN': 130.0
     Write vehicle param 'THR_MIN' : 10
@@ -122,16 +117,7 @@ The guide topic :ref:`vehicle-information` provides an explanation of how this c
 Known issues
 ============
 
-This example works around the :ref:`known issues in the API <api-information-known-issues>`. 
-Provided that the vehicle is connected and able to arm, it should run through to completion.
-
-You may observe these issues:
-
-* When the observer sets the mode callback, it waits two seconds after changing the mode before removing the observer
-  (to ensure that the callback function is run before the observer is removed). In this time you may see the callback being 
-  called twice even though the mode is only changed once. 
-  See `#60 Attribute observer callbacks are called with heartbeat until disabled - after first called  <https://github.com/dronekit/dronekit-python/issues/60>`_ 
-  for more information.
+This example has no known issues.
 
 
 

--- a/docs/guide/mavlink_messages.rst
+++ b/docs/guide/mavlink_messages.rst
@@ -7,80 +7,66 @@ MAVLink Messages
 Some useful MAVLink messages sent by the autopilot are not (yet) directly available to DroneKit-Python scripts
 through the :ref:`observable attributes <vehicle_state_observe_attributes>` in :py:class:`Vehicle <dronekit.lib.Vehicle>`.
 
-This topic shows how you can intercept all MAVLink messages using 
-:py:func:`Vehicle.set_mavlink_callback() <dronekit.lib.Vehicle.set_mavlink_callback>`.
+This topic shows how you can intercept specific MAVLink messages by defining a listener callback function 
+using the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+decorator.
 
 .. tip::
 
     :ref:`example_create_attribute` shows how you can extend this approach to create a new :py:class:`Vehicle <dronekit.lib.Vehicle>`
     attribute in your client code.
 
-    
 
+.. _mavlink_messages_message_listener:
 .. _mavlink_messages_set_mavlink_callback:
 
-Creating a message observer
+Creating a message listener
 ===========================
 
-The :py:func:`Vehicle.set_mavlink_callback() <dronekit.lib.Vehicle.set_mavlink_callback>` method provides asynchronous 
-notification when any *MAVLink* packet is received from the connected vehicle.
+The :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` decorator can be used to 
+set a particular function as the callback handler for a particular message type. You can create listeners 
+for as many messages as you like, or even multiple listeners for the same message. 
 
-The code snippet below shows how to set a “demo” callback function as the callback handler:
+For example, code snippet below shows how to set a listener for the ``RANGEFINDER`` message:
 
 .. code:: python
 
-    # Demo callback handler for raw MAVLink messages
-    def mavrx_debug_handler(message):
-        print type(message)
+    #Create a message listener using the decorator.   
+    @vehicle.message_listener('RANGEFINDER')
+    def listener(self, name, message):
         print message
-        
 
-    # Set MAVLink callback handler (after getting Vehicle instance)                     
-    vehicle.set_mavlink_callback(mavrx_debug_handler)
+.. tip::
 
-.. note::
-
-    DroneKit-Python only supports a single MAVLink message observer at a time. This can be removed or replaced 
-    with a different observer.    
+    Every single listener can have the same name/prototpye as above ("``listener``") because
+    Python does not notice these decorated functions as having the same name in the same scope.
     
-The messages are `classes <https://www.samba.org/tridge/UAV/pymavlink/apidocs/classIndex.html>`_ from the `pymavlink <http://www.qgroundcontrol.org/mavlink/pymavlink>`_ library. 
+The messages are `classes <https://www.samba.org/tridge/UAV/pymavlink/apidocs/classIndex.html>`_ from the 
+`pymavlink <http://www.qgroundcontrol.org/mavlink/pymavlink>`_ library. 
 The output of the code above looks something like:
 
 .. code:: bash
 
-    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_rangefinder_message'>
     RANGEFINDER {distance : 0.0899999961257, voltage : 0.00900000054389}
-    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_terrain_report_message'>
-    TERRAIN_REPORT {lat : -353632610, lon : 1491652299, spacing : 100, terrain_height : 583.88470459, current_height : 0.0, pending : 0, loaded : 504}
-    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_ekf_status_report_message'>
-    EKF_STATUS_REPORT {flags : 933, velocity_variance : 0.0, pos_horiz_variance : 0.0, pos_vert_variance : 0.000532002304681, compass_variance : 0.00632426189259, terrain_alt_variance : 0.0}
-    <class 'pymavlink.dialects.v10.ardupilotmega.MAVLink_vibration_message'>
-    VIBRATION {time_usec : 88430000, vibration_x : 0.0, vibration_y : 0.0, vibration_z : 0.0, clipping_0 : 0, clipping_1 : 0, clipping_2 : 0}
     ...
     
-You can access the message fields directly. For example, to access the ``RANGEFINDER`` message your handler might look like this:
+You can access the message fields directly. For example, to access the ``RANGEFINDER`` message your listener
+function might look like this:
 
 .. code:: python
 
-    # Handler for message: RANGEFINDER {distance : 0.0899999961257, voltage : 0.00900000054389}
-    def mavrx_debug_handler(message):
-        messagetype=str(message).split('{')[0].strip()
-        if messagetype=='RANGEFINDER':
-            print 'distance: %s' % message.distance
-            print 'voltage: %s' % message.voltage
+    #Create a message listener using the decorator.   
+    @vehicle.message_listener('RANGEFINDER')
+    def listener(self, name, message):
+        print 'distance: %s' % message.distance
+        print 'voltage: %s' % message.voltage
 
 
-
-    
-
-
+        
+        
 Clearing the observer
 =====================
 
-The observer is unset by calling :py:func:`Vehicle.unset_mavlink_callback <dronekit.lib.Vehicle.unset_mavlink_callback>`.
+The observer is unset by calling :py:func:`Vehicle.remove_message_listener <dronekit.lib.Vehicle.remove_message_listener>`.
 
 The observer will also be removed when the thread exits.
-
-
-    
-    

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -183,3 +183,26 @@ instrument your code in order to launch the debugger, and debug messages were in
 Debugging on DroneKit-Python 2.x is much easier. Apps are now just standalone scripts, and can be debugged 
 using standard Python methods (including the debugger/IDE of your choice). 
 
+Observing attribute changes
+---------------------------
+
+The DroneKit-Python 1.x observer functions ``vehicle.add_attribute_observer`` and ``Vehicle.remove_attribute_observer`` 
+have been replaced by :py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>`
+and :py:func:`remove_attribute_listener() <dronekit.lib.Vehicle.remove_attribute_listener>`, respectively.
+
+The functions are used in a very similar way, the main difference being that the callback function now takes two arguments
+(the vehicle and the attribute name) rather than just the attribute name.
+
+See :ref:`vehicle_state_observe_attributes` for more information.
+
+Intercepting MAVLink Messages
+-----------------------------
+
+DroneKit-Python 1.x used ``Vehicle.set_mavlink_callback()`` and ``Vehicle.unset_mavlink_callback``
+to set/unset a callback function that was invoked for every single mavlink message.
+
+In DKPY2 this has been replaced by the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+decorator, which allows you to specify a callback function that will be invoked for a single message. The same
+mechanism is used internally for message capture and to create ``Vehicle`` attributes.
+
+See :ref:`mavlink_messages` for more information.

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -868,12 +868,24 @@ class Vehicle(HasObservers):
     def message_listener(self, name):
         """
         Decorator for message listeners.
+        
+        A decorated message listener is called with three arguments every time the 
+        specified message is received: 
+        
+        * ``self`` - the current vehicle.
+        * ``name`` - the name of the message that was intercepted.
+        * ``message`` - the actual message, a `pymavlink <http://www.qgroundcontrol.org/mavlink/pymavlink>`_
+          `class <https://www.samba.org/tridge/UAV/pymavlink/apidocs/classIndex.html>`_.        
 
+        For example, in the fragment below ``my_method`` will be called for every heartbeat message:
+        
         .. code:: python
 
             @vehicle.message_listener('HEARTBEAT')
             def my_method(self, name, msg):
                 pass
+                
+        :param String name: The name of the message to be intercepted by the decorated listener function.
         """
         def decorator(fn):
             if isinstance(name, list):
@@ -895,7 +907,7 @@ class Vehicle(HasObservers):
 
     def remove_message_listener(self, name, fn):
         """
-        Removes a message listener.
+        Removes a message listener (that was added using :py:func:`message_listener`)
         """
         name = str(name)
         if name in self._message_listeners:

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -228,14 +228,16 @@ class VehicleMode(object):
     `Rover <http://rover.ardupilot.com/wiki/configuration-2/#mode_meanings>`_). If an unsupported mode is set the script
     will raise a ``KeyError`` exception.
 
-    The :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>` attribute can be queried for the current mode. The code snippet
-    below shows how to read (print) and observe changes to the mode:
+    The :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>` attribute can be queried for the current mode. 
+    The code snippet below shows how to observe changes to the mode and then read the value:
 
     .. code:: python
 
-        def mode_callback(self, mode):
-            print "Vehicle Mode", vehicle.mode
+        #Callback definition for mode observer
+        def mode_callback(self, attr_name):
+            print "Vehicle Mode", self.mode
 
+        #Add observer callback for attribute `mode`
         vehicle.on_attribute('mode', mode_callback)
 
     The code snippet below shows how to change the vehicle mode to AUTO:
@@ -245,7 +247,8 @@ class VehicleMode(object):
         # Set the vehicle into auto mode
         vehicle.mode = VehicleMode("AUTO")
 
-    For more information on getting/setting/observing the :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>` (and other attributes) see the :ref:`attributes guide <vehicle_state_attributes>`.
+    For more information on getting/setting/observing the :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>` 
+    (and other attributes) see the :ref:`attributes guide <vehicle_state_attributes>`.
 
     .. py:attribute:: name
 
@@ -277,28 +280,34 @@ class HasObservers(object):
         """
         Add an attribute listener.
 
-        The listener callback function is called with the ``vehicle`` and ``attr_name`` arguments.
-        This can be used to infer the related attribute if the same callback is used 
-        for watching several attributes.
+        The ``observer`` callback function is called with the ``self`` and ``attr_name`` 
+        arguments:
+        
+        * The ``attr_name`` (attribute name) can be used to infer which attribute has triggered
+          if the same callback is used for watching several attributes.
+        * The ``self`` attribute is the associated :py:class:`Vehicle`. If needed, it can be compared
+          to a global vehicle handle to implement vehicle-specific callback handling.
 
         The example below shows how to get callbacks for location changes:
 
         .. code:: python
 
             #Callback to print the location in global and local frames
-            def location_callback(vehicle, attr_name):
-                print "Location (Global): ", vehicle.location.global_frame
-                print "Location (Local): ", vehicle.location.local_frame
+            def location_callback(self, attr_name):
+                print "Location (Global): ", self.location.global_frame
+                print "Location (Local): ", self.location.local_frame
 
             #Add observer for the vehicle's current location
             vehicle.on_attribute('location', location_callback)
 
+          
         .. note::
-            Attribute changes will only be published for changes due to some other entity.
-            They will not be published for changes made by the local API client
-            (in order to prevent redundant notification for local changes).
 
-        :param attr_name: The attribute to watch.
+            The callback function is invoked every time the associated attribute is updated 
+            from the vehicle (the attribute value may not have *changed*).
+            The callback can be removed using :py:func:`remove_attribute_listener`.            
+        
+        :param String attr_name: The attribute to watch.
         :param observer: The callback to invoke when a change in the attribute is detected.
 
         """
@@ -311,15 +320,16 @@ class HasObservers(object):
 
     def remove_attribute_listener(self, attr_name, observer):
         """
-        Remove an attribute listener.
+        Remove an attribute listener (observer) that was previously added using :py:func:`on_attribute`.
 
-        For example, the following line would remove a previously added vehicle 'global_frame' observer called location_callback:
+        For example, the following line would remove a previously added vehicle 'global_frame' 
+        observer called ``location_callback``:
 
         .. code:: python
 
             vehicle.remove_attribute_listener('global_frame', location_callback)
 
-        :param attr_name: The attribute name that is to have an observer removed.
+        :param String attr_name: The attribute name that is to have an observer removed.
         :param observer: The callback function to remove.
 
         """
@@ -345,6 +355,16 @@ class HasObservers(object):
     def attribute_listener(self, name):
         """
         Decorator for attribute listeners.
+        
+        This is used to create/define new attribute listenters. After using this method you can 
+        register an observer for the attribute using :py:func:`on_attribute`.
+        
+        .. note:: 
+        
+            The in-built attributes already have listeners (created using this method). The
+            method is public so that you can use it to add listeners to *new* attributes. 
+        
+        The example below shows how you can create a listener for the attitude attribute.
 
         .. code:: python
 

--- a/examples/drone_delivery/drone_delivery.py
+++ b/examples/drone_delivery/drone_delivery.py
@@ -58,10 +58,10 @@ class Drone(object):
         self._log("DroneDelivery Start")
 
         # Register observers
-        self.vehicle.add_attribute_observer('armed', self.armed_callback)
-        self.vehicle.add_attribute_observer('location', self.location_callback)
-        #self.vehicle.add_attribute_observer('mode', self.mode_callback)
-        self.vehicle.add_attribute_observer('gps_0', self.gps_callback)
+        self.vehicle.on_attribute('armed', self.armed_callback)
+        self.vehicle.on_attribute('location', self.location_callback)
+        #self.vehicle.on_attribute('mode', self.mode_callback)
+        self.vehicle.on_attribute('gps_0', self.gps_callback)
 
         self._log("Waiting for GPS Lock")
 
@@ -123,7 +123,7 @@ class Drone(object):
 
     def armed_callback(self, armed):
         self._log("DroneDelivery Armed Callback")
-        self.vehicle.remove_attribute_observer('armed', self.armed_callback)
+        self.vehicle.remove_message_listener('armed', self.armed_callback)
 
     def mode_callback(self, mode):
         self._log("Mode: {0}".format(self.vehicle.mode))
@@ -132,7 +132,7 @@ class Drone(object):
         self._log("GPS: {0}".format(self.vehicle.gps_0))
         if self.gps_lock is False:
             self.gps_lock = True
-            self.vehicle.remove_attribute_observer('gps_0', self.gps_callback)
+            self.vehicle.remove_message_listener('gps_0', self.gps_callback)
             self.run()
 
     def _log(self, message):

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -104,12 +104,15 @@ while not vehicle.armed:
     time.sleep(1)
 
 
-# Show how to add and remove and attribute observer callbacks (using mode as example) 
-def mode_callback(attribute):
-    print " CALLBACK: Mode changed to: ", vehicle.mode.name
+# Add and remove and attribute callbacks (using mode as example)     
+def mode_callback(self, attr_name):
+    # `attr_name` is the observed attribute (used if callback is used for multiple attributes)
+    # `self` is the associated vehicle object (used if callback behaviouris different for multiple vehicles)
+    print " CALLBACK: Mode changed to", self.mode
 
-print "\nAdd mode attribute observer for Vehicle.mode" 
-vehicle.add_attribute_observer('mode', mode_callback)
+print "\nAdd attribute callback/observer on `vehicle` for `mode` attribute"     
+vehicle.on_attribute('mode', mode_callback)    
+
 
 print " Set mode=STABILIZE (currently: %s)" % vehicle.mode.name 
 vehicle.mode = VehicleMode("STABILIZE")
@@ -117,8 +120,9 @@ vehicle.mode = VehicleMode("STABILIZE")
 print " Wait 2s so callback invoked before observer removed"
 time.sleep(2)
 
-# Remove observer - specifying the attribute and previously registered callback function
-vehicle.remove_attribute_observer('mode', mode_callback)
+print " Remove Vehicle.mode observer"    
+# Remove observer added with `on_attribute()`  - specifying the attribute and callback function
+vehicle.remove_attribute_listener('mode', mode_callback)
 
 
 # Get/Set Vehicle Parameters


### PR DESCRIPTION
This updates the main examples and API ref for attribute observers and for message listeners. There are a couple of outstanding questions around listeners, and I understand @tcr3dr is going to rename some of the attribute observer methods.

This also updates the migration guide with information about attribute observers and message listeners (the information is "high level" and refers back to the relevant guide sections)

At time of writing it does not 

- update drone_delivery