### PR TITLE
Attribute handler refactoring

### DIFF
--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -166,7 +166,7 @@ the attribute and then notifies all observers.
         self.raw_imu.zmag=message.zmag
         
         # Notify all observers of new message.
-        self._notify_attribute_listeners('raw_imu') 
+        self.notify_attribute_listeners('raw_imu') 
 
 
 .. note:: 

--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -7,10 +7,10 @@ Example: Create Attribute in App
 This example shows how you can create attributes for MAVLink messages within your DroneKit-Python script and 
 use them in *in the same way* as the built-in :py:class:`Vehicle <dronekit.lib.Vehicle>` attributes.
 
-It uses the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` decorator
+It uses the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator
 to set a function that is called to process a specific message, copy its values into an attribute, and notify
 observers. An observer is then set on the new attribute using 
-:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>`.
+:py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>`.
 
 Additional information is provided in the guide topic :ref:`mavlink_messages`.
 
@@ -143,7 +143,7 @@ All values in the new attribute should be set to ``None`` so that it is obvious 
     #Create an Vehicle.raw_imu object and set all values to None.
     vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
     
-We create a listener using the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+We create a listener using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
 decorator as shown below. The listener is called for messages that contain the string "RAW_IMU", 
 with arguments for the vehicle, message name, and the message. It copies the message information into 
 the attribute and then notifies all observers.
@@ -151,7 +151,7 @@ the attribute and then notifies all observers.
 .. code:: python
 
     #Create a message listener using the decorator.   
-    @vehicle.message_listener('RAW_IMU')
+    @vehicle.on_message('RAW_IMU')
     def listener(self, name, message):
         #Copy the message contents into the raw_imu attribute
         self.raw_imu.time_boot_us=message.time_usec
@@ -187,7 +187,7 @@ You can query the attribute to get any of its members, and even add an observer 
 
 
     #Add observer for the vehicle's current location
-    vehicle.on_attribute('raw_imu', raw_imu_callback)
+    vehicle.add_attribute_listener('raw_imu', raw_imu_callback)
 
 
 Known issues

--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -111,7 +111,7 @@ representation for printing the object.
         :param zmag: Z Magnetic field (milli tesla)    
         """
 
-        def __init__(self, time_boot_us, xacc, yacc, zacc, xygro, ygyro, zgyro, xmag, ymag, zmag):
+        def __init__(self, time_boot_us=None, xacc=None, yacc=None, zacc=None, xygro=None, ygyro=None, zgyro=None, xmag=None, ymag=None, zmag=None):
             """
             RawIMU object constructor.
             """
@@ -140,8 +140,8 @@ All values in the new attribute should be set to ``None`` so that it is obvious 
     # Connect to the Vehicle passed in as args.connect
     vehicle = connect(args.connect, wait_ready=True)
 
-    #Create an Vehicle.raw_imu object and set all values to None.
-    vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
+    #Create an Vehicle.raw_imu object with values set to `None`.
+    vehicle.raw_imu=RawIMU()
     
 We create a listener using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
 decorator as shown below. The listener is called for messages that contain the string "RAW_IMU", 
@@ -165,8 +165,8 @@ the attribute and then notifies all observers.
         self.raw_imu.ymag=message.ymag
         self.raw_imu.zmag=message.zmag
         
-        # Notify all observers of new message.
-        self.notify_attribute_listeners('raw_imu') 
+        # Notify all observers of new message with new value
+        self.notify_attribute_listeners('raw_imu', self.raw_imu) 
 
 
 .. note:: 
@@ -182,8 +182,9 @@ You can query the attribute to get any of its members, and even add an observer 
 .. code:: python
 
     #Callback to print the raw_imu
-    def raw_imu_callback(self, attr_name):
-        print self.raw_imu
+    def raw_imu_callback(self, attr_name, msg):
+        #msg is the value/attribute that was updated.
+        print msg
 
 
     #Add observer for the vehicle's current location

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -49,31 +49,30 @@ On the command prompt you should see (something like):
 
 .. code:: bash
 
-    Connecting to vehicle on: 127.0.0.1:14550
     >>> APM:Copter V3.3 (d6053245)
     >>> Frame: QUAD
 
     Accumulating vehicle attribute messages
 
     Get all vehicle attribute values:
-     Global Location: LocationGlobal:lat=-35.3632585,lon=149.165227,alt=362.0,is_relative=False
+     Global Location: LocationGlobal:lat=-35.3632361,lon=149.1652374,alt=361.989990234,is_relative=False
      Local Location: LocationLocal:north=None,east=None,down=None
-     Attitude: Attitude:pitch=-0.00352983362973,yaw=-0.0589601770043,roll=-0.00761049194261
-     Velocity: [0.02, -0.02, 0.0]
+     Attitude: Attitude:pitch=-0.0078572165221,yaw=-0.352846503258,roll=0.00523957656696
+     Velocity: [-0.02, 0.01, 0.0]
      GPS: GPSInfo:fix=3,num_sat=10
      Groundspeed: 0.0
      Airspeed: 0.0
      Mount status: [None, None, None]
-     Battery: Battery:voltage=12.587,current=0.0,level=98
+     Battery: Battery:voltage=12.587,current=0.0,level=95
      Rangefinder: Rangefinder: distance=None, voltage=None
      Rangefinder distance: None
      Rangefinder voltage: None
      Mode: STABILIZE
      Armed: False
-     Home Location: LocationGlobal:lat=-35.3632583618,lon=149.165222168,alt=222.0,is_relative=False
+     Home Location: LocationGlobal:lat=-35.3632392883,lon=149.165237427,alt=222.0,is_relative=False
 
     Set new home location
-     New Home Location (altitude should be 222): LocationGlobal:lat=-35.3632583618,lon=149.165222168,alt=222.0,is_relative=False
+     New Home Location (altitude should be 222): LocationGlobal:lat=-35.3632354736,lon=149.165237427,alt=222.0,is_relative=False
 
     Set Vehicle.mode=GUIDED (currently: STABILIZE)
      Waiting for mode change ...
@@ -87,8 +86,34 @@ On the command prompt you should see (something like):
      Set mode=STABILIZE (currently: GUIDED)
      Wait 2s so callback invoked before observer removed
      CALLBACK: Mode changed to VehicleMode:STABILIZE
-     CALLBACK: Mode changed to VehicleMode:STABILIZE
      Remove Vehicle.mode observer
+
+    Add attribute callback/observer `mode` attribute using decorator
+     Set mode=GUIDED (currently: STABILIZE)
+     Wait 2s so callback invoked before observer removed
+     CALLBACK: Mode changed to VehicleMode:GUIDED
+
+     Attempt to remove observer added with `on_attribute` decorator (should fail)
+     Exception: Cannot add observer added using decorator
+
+    Add attribute calback detecting any attribute change
+     Wait 1s so callback invoked before observer removed
+     CALLBACK: (battery): Battery:voltage=12.538,current=3.48,level=95
+     CALLBACK: (gps_0): GPSInfo:fix=3,num_sat=10
+     CALLBACK: (location): LocationGlobal:lat=-35.3632361,lon=149.1652379,alt=361.989990234,is_relative=False
+     CALLBACK: (velocity): [-0.01, 0.03, 0.0]
+     CALLBACK: (local_position): LocationLocal:north=2.78085613251,east=0.730665147305,down=0.00156301062088
+     CALLBACK: (attitude): Attitude:pitch=-0.00780974514782,yaw=-0.361094027758,roll=0.00564418500289
+     CALLBACK: (heading): 339
+     CALLBACK: (location): LocationGlobal:lat=-35.3632361,lon=149.1652379,alt=361.989990234,is_relative=False
+     CALLBACK: (airspeed): 0.019999999553
+     CALLBACK: (groundspeed): 0.019999999553
+     CALLBACK: (ekf_ok): True
+     CALLBACK: (armed): True
+     CALLBACK: (mode): VehicleMode:GUIDED
+     ...
+     CALLBACK: (ekf_ok): True
+     Remove Vehicle attribute observer
 
     Read vehicle param 'THR_MIN': 130.0
     Write vehicle param 'THR_MIN' : 10
@@ -96,6 +121,7 @@ On the command prompt you should see (something like):
 
     Reset vehicle attributes/parameters and exit
     >>> DISARMING MOTORS
+     CALLBACK: Mode changed to VehicleMode:STABILIZE
 
     Close vehicle object
     Completed

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -67,6 +67,8 @@ On the command prompt you should see (something like):
      Rangefinder: Rangefinder: distance=None, voltage=None
      Rangefinder distance: None
      Rangefinder voltage: None
+     System status: 3
+     Heading: 341
      Mode: STABILIZE
      Armed: False
      Home Location: LocationGlobal:lat=-35.3632392883,lon=149.165237427,alt=222.0,is_relative=False

--- a/docs/guide/mavlink_messages.rst
+++ b/docs/guide/mavlink_messages.rst
@@ -8,8 +8,7 @@ Some useful MAVLink messages sent by the autopilot are not (yet) directly availa
 through the :ref:`observable attributes <vehicle_state_observe_attributes>` in :py:class:`Vehicle <dronekit.lib.Vehicle>`.
 
 This topic shows how you can intercept specific MAVLink messages by defining a listener callback function 
-using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
-decorator.
+using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator.
 
 .. tip::
 
@@ -27,7 +26,7 @@ The :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator 
 set a particular function as the callback handler for a particular message type. You can create listeners 
 for as many messages as you like, or even multiple listeners for the same message. 
 
-For example, code snippet below shows how to set a listener for the ``RANGEFINDER`` message:
+For example, the code snippet below shows how to set a listener for the ``RANGEFINDER`` message:
 
 .. code:: python
 
@@ -39,7 +38,9 @@ For example, code snippet below shows how to set a listener for the ``RANGEFINDE
 .. tip::
 
     Every single listener can have the same name/prototpye as above ("``listener``") because
-    Python does not notice these decorated functions as having the same name in the same scope.
+    Python does not notice the decorated functions are in the same scope.
+    
+    Unfortunately this also means that you can't unregister a callback created using this method.
     
 The messages are `classes <https://www.samba.org/tridge/UAV/pymavlink/apidocs/classIndex.html>`_ from the 
 `pymavlink <http://www.qgroundcontrol.org/mavlink/pymavlink>`_ library. 
@@ -62,11 +63,25 @@ function might look like this:
         print 'voltage: %s' % message.voltage
 
 
-        
-        
-Clearing the observer
+Watching all messages
 =====================
 
-The observer is unset by calling :py:func:`Vehicle.remove_message_listener <dronekit.lib.Vehicle.remove_message_listener>`.
+You can register a callback for *all messages* by setting the message name as the wildcard string ('``*``'):
 
-The observer will also be removed when the thread exits.
+.. code:: python
+
+    #Create a message listener for all messages.   
+    @vehicle.on_message('*')
+    def listener(self, name, message):
+        print 'message: %s' % message
+        
+        
+Removing an observer
+====================
+
+Callbacks registered using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator *cannot be removed*. 
+This is generally not a problem, because in most cases you're interested in messages for the lifetime of a session.
+
+If you do need to be able to remove messages you can instead add the callback using 
+:py:func:`Vehicle.add_message_listener <dronekit.lib.Vehicle.add_message_listener>`, and then remove it by calling 
+:py:func:`Vehicle.remove_message_listener <dronekit.lib.Vehicle.remove_message_listener>`.

--- a/docs/guide/mavlink_messages.rst
+++ b/docs/guide/mavlink_messages.rst
@@ -8,7 +8,7 @@ Some useful MAVLink messages sent by the autopilot are not (yet) directly availa
 through the :ref:`observable attributes <vehicle_state_observe_attributes>` in :py:class:`Vehicle <dronekit.lib.Vehicle>`.
 
 This topic shows how you can intercept specific MAVLink messages by defining a listener callback function 
-using the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
 decorator.
 
 .. tip::
@@ -23,7 +23,7 @@ decorator.
 Creating a message listener
 ===========================
 
-The :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` decorator can be used to 
+The :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator can be used to 
 set a particular function as the callback handler for a particular message type. You can create listeners 
 for as many messages as you like, or even multiple listeners for the same message. 
 
@@ -32,7 +32,7 @@ For example, code snippet below shows how to set a listener for the ``RANGEFINDE
 .. code:: python
 
     #Create a message listener using the decorator.   
-    @vehicle.message_listener('RANGEFINDER')
+    @vehicle.on_message('RANGEFINDER')
     def listener(self, name, message):
         print message
 
@@ -56,7 +56,7 @@ function might look like this:
 .. code:: python
 
     #Create a message listener using the decorator.   
-    @vehicle.message_listener('RANGEFINDER')
+    @vehicle.on_message('RANGEFINDER')
     def listener(self, name, message):
         print 'distance: %s' % message.distance
         print 'voltage: %s' % message.voltage

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -174,26 +174,27 @@ This code must be replaced with the DroneKit-Python 2.x :py:attr:`Vehicle.home_l
     :py:attr:`Vehicle.home_location <dronekit.lib.Vehicle.home_location>`. 
 
 
-Debugging
-=========
-
-DroneKit-Python 1.x scripts were run in the context of a MAVProxy. This made them difficult to debug because you had to 
-instrument your code in order to launch the debugger, and debug messages were interleaved with MAVProxy output.
-
-Debugging on DroneKit-Python 2.x is much easier. Apps are now just standalone scripts, and can be debugged 
-using standard Python methods (including the debugger/IDE of your choice). 
 
 Observing attribute changes
 ---------------------------
 
-The DroneKit-Python 1.x observer functions ``vehicle.add_attribute_observer`` and ``Vehicle.remove_attribute_observer`` 
-have been replaced by :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>`
-and :py:func:`remove_attribute_listener() <dronekit.lib.Vehicle.remove_attribute_listener>`, respectively.
+The DroneKit-Python 1.x observer function ``vehicle.add_attribute_observer`` has been replaced by 
+:py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>` or 
+:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` in DKYP2.x,  and ``Vehicle.remove_attribute_observer`` 
+has been repaced by :py:func:`remove_attribute_listener() <dronekit.lib.Vehicle.remove_attribute_listener>`.
 
-The functions are used in a very similar way, the main difference being that the callback function now takes two arguments
-(the vehicle and the attribute name) rather than just the attribute name.
+The main difference is that the callback function now takes three arguments (the vehicle object, attribute name, attribute value)
+rather than just the attribute name. This allows you to more easily write callbacks that support attribute-specific and 
+vehicle-specific handling and means that you can get the new value from the callback attribute rather than by re-querying
+the vehicle. 
+
+The difference between :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>` and 
+:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` is that attribute listeners added using
+:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` cannot be removed (but ``on_attribute()`` does have
+a more elegant syntax).
 
 See :ref:`vehicle_state_observe_attributes` for more information.
+
 
 Intercepting MAVLink Messages
 -----------------------------
@@ -202,7 +203,27 @@ DroneKit-Python 1.x used ``Vehicle.set_mavlink_callback()`` and ``Vehicle.unset_
 to set/unset a callback function that was invoked for every single mavlink message.
 
 In DKPY2 this has been replaced by the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
-decorator, which allows you to specify a callback function that will be invoked for a single message. The same
-mechanism is used internally for message capture and to create ``Vehicle`` attributes.
+decorator, which allows you to specify a callback function that will be invoked for a single message 
+(or all messages, by specifying the message name as the wildcard string '``*``').
+
+.. tip::
+
+    :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` is used in core DroneKit code for 
+    message capture and to create ``Vehicle`` attributes.
+
+    The API also adds :py:func:`Vehicle.add_message_listener() <dronekit.lib.Vehicle.add_message_listener>`
+    and :py:func:`Vehicle.remove_message_listener() <dronekit.lib.Vehicle.remove_message_listener>`. 
+    These can be used instead of :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` when you need to be
+    able to *remove* an added listener.
 
 See :ref:`mavlink_messages` for more information.
+
+
+Debugging
+=========
+
+DroneKit-Python 1.x scripts were run in the context of a MAVProxy. This made them difficult to debug because you had to 
+instrument your code in order to launch the debugger, and debug messages were interleaved with MAVProxy output.
+
+Debugging on DroneKit-Python 2.x is much easier. Apps are now just standalone scripts, and can be debugged 
+using standard Python methods (including the debugger/IDE of your choice). 

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -160,6 +160,8 @@ Instead, use normal Python methods for getting file system information:
     import os.path
     full_directory_path_of_current_script = os.path.dirname(os.path.abspath(__file__))
 
+    
+.. _migrating_dkpy2_0_heading:
 
 Home location
 -------------
@@ -217,6 +219,15 @@ decorator, which allows you to specify a callback function that will be invoked 
     able to *remove* an added listener.
 
 See :ref:`mavlink_messages` for more information.
+
+
+New attributes
+--------------
+
+In addition to the :ref:`home_location <migrating_dkpy2_0_heading>`, a few more attributes have been added, 
+including:
+:py:func:`Vehicle.system_status <dronekit.lib.Vehicle.system_status>` and 
+:py:func:`Vehicle.heading <dronekit.lib.Vehicle.heading>`. 
 
 
 Debugging

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -187,7 +187,7 @@ Observing attribute changes
 ---------------------------
 
 The DroneKit-Python 1.x observer functions ``vehicle.add_attribute_observer`` and ``Vehicle.remove_attribute_observer`` 
-have been replaced by :py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>`
+have been replaced by :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>`
 and :py:func:`remove_attribute_listener() <dronekit.lib.Vehicle.remove_attribute_listener>`, respectively.
 
 The functions are used in a very similar way, the main difference being that the callback function now takes two arguments
@@ -201,7 +201,7 @@ Intercepting MAVLink Messages
 DroneKit-Python 1.x used ``Vehicle.set_mavlink_callback()`` and ``Vehicle.unset_mavlink_callback``
 to set/unset a callback function that was invoked for every single mavlink message.
 
-In DKPY2 this has been replaced by the :py:func:`Vehicle.message_listener() <dronekit.lib.Vehicle.message_listener>` 
+In DKPY2 this has been replaced by the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
 decorator, which allows you to specify a callback function that will be invoked for a single message. The same
 mechanism is used internally for message capture and to create ``Vehicle`` attributes.
 

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -31,6 +31,8 @@ Vehicle state information is exposed through vehicle *attributes*. DroneKit-Pyth
 :py:attr:`Vehicle.battery <dronekit.lib.Vehicle.battery>`,
 :py:attr:`Vehicle.rangefinder <dronekit.lib.Vehicle.rangefinder>`,
 :py:attr:`Vehicle.home_location <dronekit.lib.Vehicle.home_location>`,
+:py:func:`Vehicle.system_status <dronekit.lib.Vehicle.system_status>`,
+:py:func:`Vehicle.heading <dronekit.lib.Vehicle.heading>`,
 :py:attr:`Vehicle.armed <dronekit.lib.Vehicle.armed>`,
 :py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>`.
 
@@ -51,8 +53,8 @@ from the other attributes, and is :ref:`discussed in its own section below <vehi
 Getting attributes
 ------------------
 
-The code fragment below shows how to read and print almost the attributes. The values are retrieved from the remote device 
-(not cached).
+The code fragment below shows how to read and print almost all the attributes (values are
+regularly updated from MAVLink messages sent by the vehicle).
 
 .. code:: python
     
@@ -69,6 +71,8 @@ The code fragment below shows how to read and print almost the attributes. The v
     print "Rangefinder: %s" % vehicle.rangefinder
     print "Rangefinder distance: %s" % vehicle.rangefinder.distance
     print "Rangefinder voltage: %s" % vehicle.rangefinder.voltage
+    print "Heading: %s" % vehicle.heading
+    print "System status: %s" % vehicle.system_status
     print "Mode: %s" % vehicle.mode.name    # settable
     print "Armed: %s" % vehicle.armed    # settable
 
@@ -307,7 +311,6 @@ throttle at which the motors will keep spinning.
     # Print the value of the THR_MIN parameter.
     print "Param: %s" % vehicle.parameters['THR_MIN']
 
-    
 
 
 Setting parameters

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -139,7 +139,7 @@ You can observe any of the attributes (except for :py:attr:`Vehicle.home_locatio
 :py:attr:`Vehicle.parameters <dronekit.lib.Vehicle.parameters>`) and will receive notification every time a value is received 
 from the connected vehicle.  This allows you to monitor changes to velocity and other vehicle state without the need for polling.
 
-Observers are added using :py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>`, 
+Observers are added using :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>`, 
 specifying the name of the attribute to observe and a callback function. 
 Observers are removed using :py:func:`remove_attribute_listener() <dronekit.lib.Vehicle.remove_attribute_listener>`.
 
@@ -163,7 +163,7 @@ callback is first run.
         print "Location (Local): ", self.location.local_frame
         
     # Add a callback. The first parameter the name of the observed attribute (a string).
-    vehicle.on_attribute('location', location_callback)
+    vehicle.add_attribute_listener('location', location_callback)
 
     # Wait 2s so callback can be notified before the observer is removed
     time.sleep(2)
@@ -189,7 +189,7 @@ For example, the following code can be used in the callback to only print output
         last_rangefinder_distance = round(self.rangefinder.distance, 1)
         print " Rangefinder (metres): %s" % last_rangefinder_distance
 
-    vehicle.on_attribute('rangefinder', rangefinder_callback)
+    vehicle.add_attribute_listener('rangefinder', rangefinder_callback)
 
 
 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -146,13 +146,13 @@ class MAVHandler:
         if hasattr(message, 'target_component'):
             message.target_component = self.target_component
 
-    def loop_listener(self, fn):
+    def forward_loop(self, fn):
         """
         Decorator for event loop.
         """
         self.loop_listeners.append(fn)
 
-    def message_listener(self, fn):
+    def forward_message(self, fn):
         """
         Decorator for message inputs.
         """
@@ -174,7 +174,7 @@ def connect(ip, wait_ready=None, status_printer=errprinter, vehicle_class=Vehicl
     vehicle = vehicle_class(handler)
 
     if status_printer:
-        @vehicle.message_listener('STATUSTEXT')
+        @vehicle.on_message('STATUSTEXT')
         def listener(self, name, m):
             status_printer(re.sub(r'(^|\n)', '>>> ', m.text.rstrip()))
     

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -339,7 +339,7 @@ class HasObservers(object):
             if len(l) == 0:
                 del self.__observers[attr_name]
 
-    def _notify_attribute_listeners(self, attr_name):
+    def notify_attribute_listeners(self, attr_name):
         """
         Internal function. Do not use.
 
@@ -577,7 +577,7 @@ class Vehicle(HasObservers):
 
         @handler.forward_message
         def listener(_, msg):
-            self._notify_message_listeners(msg.get_type(), msg)
+            self.notify_message_listeners(msg.get_type(), msg)
 
         self._lat = None
         self._lon = None
@@ -588,9 +588,9 @@ class Vehicle(HasObservers):
         @self.on_message('GLOBAL_POSITION_INT')
         def listener(self, name, m):
             (self._lat, self._lon) = (m.lat / 1.0e7, m.lon / 1.0e7)
-            self._notify_attribute_listeners('location')
+            self.notify_attribute_listeners('location')
             (self._vx, self._vy, self._vz) = (m.vx / 100.0, m.vy / 100.0, m.vz / 100.0)
-            self._notify_attribute_listeners('velocity')
+            self.notify_attribute_listeners('velocity')
 
         self._north = None
         self._east = None
@@ -601,7 +601,7 @@ class Vehicle(HasObservers):
             self._north = m.x
             self._east = m.y
             self._down = m.z
-            self._notify_attribute_listeners('local_position')
+            self.notify_attribute_listeners('local_position')
 
         self._pitch = None
         self._yaw = None
@@ -618,7 +618,7 @@ class Vehicle(HasObservers):
             self._pitchspeed = m.pitchspeed
             self._yawspeed = m.yawspeed
             self._rollspeed = m.rollspeed
-            self._notify_attribute_listeners('attitude')
+            self.notify_attribute_listeners('attitude')
 
         self._heading = None
         self._alt = None
@@ -628,13 +628,13 @@ class Vehicle(HasObservers):
         @self.on_message('VFR_HUD')
         def listener(self, name, m):
             self._heading = m.heading
-            self._notify_attribute_listeners('heading')
+            self.notify_attribute_listeners('heading')
             self._alt = m.alt
-            self._notify_attribute_listeners('location')
+            self.notify_attribute_listeners('location')
             self._airspeed = m.airspeed
-            self._notify_attribute_listeners('airspeed')
+            self.notify_attribute_listeners('airspeed')
             self._groundspeed = m.groundspeed
-            self._notify_attribute_listeners('groundspeed')
+            self.notify_attribute_listeners('groundspeed')
 
         self._rngfnd_distance = None
         self._rngfnd_voltage = None
@@ -643,7 +643,7 @@ class Vehicle(HasObservers):
         def listener(self, name, m):
             self._rngfnd_distance = m.distance
             self._rngfnd_voltage = m.voltage
-            self._notify_attribute_listeners('rangefinder')
+            self.notify_attribute_listeners('rangefinder')
 
         self._mount_pitch = None
         self._mount_yaw = None
@@ -654,7 +654,7 @@ class Vehicle(HasObservers):
             self._mount_pitch = m.pointing_a / 100
             self._mount_roll = m.pointing_b / 100
             self._mount_yaw = m.pointing_c / 100
-            self._notify_attribute_listeners('mount')
+            self.notify_attribute_listeners('mount')
 
         self._rc_readback = {}
 
@@ -683,7 +683,7 @@ class Vehicle(HasObservers):
             self._voltage = m.voltage_battery
             self._current = m.current_battery
             self._level = m.battery_remaining
-            self._notify_attribute_listeners('battery')
+            self.notify_attribute_listeners('battery')
 
         self._eph = None
         self._epv = None
@@ -696,7 +696,7 @@ class Vehicle(HasObservers):
             self._epv = m.epv
             self._satellites_visible = m.satellites_visible
             self._fix_type = m.fix_type
-            self._notify_attribute_listeners('gps_0')
+            self.notify_attribute_listeners('gps_0')
 
         self._current_waypoint = 0
 
@@ -717,7 +717,7 @@ class Vehicle(HasObservers):
             # boolean: EKF's predicted horizontal position (absolute) estimate is good
             self._ekf_predposhorizabs = (m.flags & ardupilotmega.EKF_PRED_POS_HORIZ_ABS) > 0
 
-            self._notify_attribute_listeners('ekf_ok')
+            self.notify_attribute_listeners('ekf_ok')
 
         self._flightmode = 'AUTO'
         self._armed = False
@@ -726,10 +726,10 @@ class Vehicle(HasObservers):
         @self.on_message('HEARTBEAT')
         def listener(self, name, m):
             self._armed = (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED) != 0
-            self._notify_attribute_listeners('armed')
+            self.notify_attribute_listeners('armed')
             self._flightmode = {v: k for k, v in self._master.mode_mapping().items()}[m.custom_mode]
             self._system_status = m.system_status
-            self._notify_attribute_listeners('mode')
+            self.notify_attribute_listeners('mode')
 
         # Waypoints.
 
@@ -762,7 +762,7 @@ class Vehicle(HasObservers):
                         self._master.waypoint_request_send(msg.seq + 1)
                     else:
                         self._wp_loaded = True
-                        self._notify_attribute_listeners('commands')
+                        self.notify_attribute_listeners('commands')
 
         # Waypoint send to master
         @self.on_message(['WAYPOINT_REQUEST', 'MISSION_REQUEST'])
@@ -795,7 +795,7 @@ class Vehicle(HasObservers):
             if self._params_start:
                 if None not in self._params_set and not self._params_loaded:
                     self._params_loaded = True
-                    self._notify_attribute_listeners('parameters')
+                    self.notify_attribute_listeners('parameters')
 
                 if not self._params_loaded and time.time() - self._params_last > self._params_duration:
                     c = 0
@@ -915,7 +915,7 @@ class Vehicle(HasObservers):
             if len(self._message_listeners[name]) == 0:
                 del self._message_listeners[name]
 
-    def _notify_message_listeners(self, name, msg):
+    def notify_message_listeners(self, name, msg):
         for fn in self._message_listeners.get(name, []):
             fn(self, name, msg)
         for fn in self._message_listeners.get('*', []):

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -1052,10 +1052,29 @@ class Vehicle(HasObservers):
 
     @property
     def system_status(self):
+        """
+        System status flag according to the MAVLink 
+        `MAV_STATE <http://mavlink.org/messages/common#MAV_STATE_UNINIT>`_ enum.
+        
+        States include:
+        
+        * ``MAV_STATE_UNINIT`` (0): Uninitialized system, state is unknown.
+        * ``MAV_STATE_BOOT`` (1): System is booting up.
+        * ``MAV_STATE_CALIBRATING`` (2): System is calibrating and not flight-ready.
+        * ``MAV_STATE_STANDBY`` (3): System is grounded and on standby. It can be launched any time.
+        * ``MAV_STATE_ACTIVE`` (4): System is active and might be already airborne. Motors are engaged.
+        * ``MAV_STATE_CRITICAL`` (5): System is in a non-normal flight mode. It can however still navigate.
+        * ``MAV_STATE_EMERGENCY`` (6): System is in a non-normal flight mode. It lost control over parts 
+          or over the whole airframe. It is in mayday and going down.
+        * ``MAV_STATE_POWEROFF`` (7): System just initialized its power-down sequence, will shut down now.
+        """
         return self._system_status
 
     @property
     def heading(self):
+        """
+        Current heading in degrees (0..360, where North = 0).
+        """
         return self._heading
 
     @property

--- a/dronekit/test/sitl/test_110.py
+++ b/dronekit/test/sitl/test_110.py
@@ -26,13 +26,13 @@ def test_110(connpath):
         armed_callback.called += 1
     armed_callback.called = 0
 
-    # When the same (event, callback) pair is passed to on_attribute,
+    # When the same (event, callback) pair is passed to add_attribute_listener,
     # only one instance of the observer callback should be added.
-    vehicle.on_attribute('armed', armed_callback)
-    vehicle.on_attribute('armed', armed_callback)
-    vehicle.on_attribute('armed', armed_callback)
-    vehicle.on_attribute('armed', armed_callback)
-    vehicle.on_attribute('armed', armed_callback)
+    vehicle.add_attribute_listener('armed', armed_callback)
+    vehicle.add_attribute_listener('armed', armed_callback)
+    vehicle.add_attribute_listener('armed', armed_callback)
+    vehicle.add_attribute_listener('armed', armed_callback)
+    vehicle.add_attribute_listener('armed', armed_callback)
 
     # Disarm and see update.
     vehicle.armed = False

--- a/dronekit/test/sitl/test_110.py
+++ b/dronekit/test/sitl/test_110.py
@@ -22,7 +22,7 @@ def test_110(connpath):
     time.sleep(3)
 
     # Define example callback for mode
-    def armed_callback(vehicle, attribute):
+    def armed_callback(vehicle, attribute, value):
         armed_callback.called += 1
     armed_callback.called = 0
 

--- a/dronekit/test/sitl/test_115.py
+++ b/dronekit/test/sitl/test_115.py
@@ -15,7 +15,7 @@ def test_115(connpath):
     mavlink_callback.count = 0
 
     # Set the callback.
-    v.on_message('*', mavlink_callback)
+    v.add_message_listener('*', mavlink_callback)
 
     # Change the vehicle into STABILIZE mode
     v.mode = VehicleMode("STABILIZE")

--- a/dronekit/test/sitl/test_vehicleclass.py
+++ b/dronekit/test/sitl/test_vehicleclass.py
@@ -10,7 +10,7 @@ class DummyVehicle(Vehicle):
 		self.success = False
 		def success_fn(self, name, m):
 			self.success = True
-		self.on_message('HEARTBEAT', success_fn)
+		self.add_message_listener('HEARTBEAT', success_fn)
 
 @with_sitl
 def test_timeout(connpath):

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -105,7 +105,7 @@ From this point vehicle.raw_imu can be used just like any other attribute.
 """
 
 #Callback to print the raw_imu
-def raw_imu_callback(self,rawimu,msg):
+def raw_imu_callback(self,attr_name,msg):
     #msg is the attribute/value that changed
     print msg
 

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -76,7 +76,7 @@ vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
 
 
 #Create a message listener using the decorator.   
-@vehicle.message_listener('RAW_IMU')
+@vehicle.on_message('RAW_IMU')
 def listener(self, name, message):
     """
     The listener is called for messages that contain the string specified in the decorator,
@@ -110,7 +110,7 @@ def raw_imu_callback(self,rawimu):
 
 
 #Add observer for the vehicle's current location
-vehicle.on_attribute('raw_imu', raw_imu_callback)
+vehicle.add_attribute_listener('raw_imu', raw_imu_callback)
 
 print 'Display RAW_IMU messages for 5 seconds and then exit.'
 time.sleep(5)

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -97,7 +97,7 @@ def listener(self, name, message):
     self.raw_imu.zmag=message.zmag
     
     # Notify all observers of new message.
-    self._notify_attribute_listeners('raw_imu') 
+    self.notify_attribute_listeners('raw_imu') 
     
 
 """

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -47,7 +47,7 @@ class RawIMU(object):
     :param ymag: Y Magnetic field (milli tesla)
     :param zmag: Z Magnetic field (milli tesla)    
     """
-    def __init__(self, time_boot_us, xacc, yacc, zacc, xygro, ygyro, zgyro, xmag, ymag, zmag):
+    def __init__(self, time_boot_us=None, xacc=None, yacc=None, zacc=None, xygro=None, ygyro=None, zgyro=None, xmag=None, ymag=None, zmag=None):
         """
         RawIMU object constructor.
         """
@@ -70,8 +70,8 @@ class RawIMU(object):
 
    
 
-#Create an Vehicle.raw_imu object and set all values to None.
-vehicle.raw_imu=RawIMU(None,None,None,None,None,None,None,None,None,None)
+#Create an Vehicle.raw_imu object with initial values set to None.
+vehicle.raw_imu=RawIMU()
  
 
 
@@ -96,8 +96,8 @@ def listener(self, name, message):
     self.raw_imu.ymag=message.ymag
     self.raw_imu.zmag=message.zmag
     
-    # Notify all observers of new message.
-    self.notify_attribute_listeners('raw_imu') 
+    # Notify all observers of new message (with new value)
+    self.notify_attribute_listeners('raw_imu', self.raw_imu) 
     
 
 """
@@ -105,8 +105,9 @@ From this point vehicle.raw_imu can be used just like any other attribute.
 """
 
 #Callback to print the raw_imu
-def raw_imu_callback(self,rawimu):
-    print self.raw_imu
+def raw_imu_callback(self,rawimu,msg):
+    #msg is the attribute/value that changed
+    print msg
 
 
 #Add observer for the vehicle's current location

--- a/examples/drone_delivery/drone_delivery.py
+++ b/examples/drone_delivery/drone_delivery.py
@@ -58,10 +58,10 @@ class Drone(object):
         self._log("DroneDelivery Start")
 
         # Register observers
-        self.vehicle.on_attribute('armed', self.armed_callback)
-        self.vehicle.on_attribute('location', self.location_callback)
-        #self.vehicle.on_attribute('mode', self.mode_callback)
-        self.vehicle.on_attribute('gps_0', self.gps_callback)
+        self.vehicle.add_attribute_listener('armed', self.armed_callback)
+        self.vehicle.add_attribute_listener('location', self.location_callback)
+        #self.vehicle.add_attribute_listener('mode', self.mode_callback)
+        self.vehicle.add_attribute_listener('gps_0', self.gps_callback)
 
         self._log("Waiting for GPS Lock")
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -46,6 +46,8 @@ print " Battery: %s" % vehicle.battery
 print " Rangefinder: %s" % vehicle.rangefinder
 print " Rangefinder distance: %s" % vehicle.rangefinder.distance
 print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
+print " Heading: %s" % vehicle.heading
+print " System status: %s" % vehicle.system_status
 print " Mode: %s" % vehicle.mode.name    # settable
 print " Armed: %s" % vehicle.armed    # settable
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -111,7 +111,7 @@ def mode_callback(self, attr_name):
     print " CALLBACK: Mode changed to", self.mode
 
 print "\nAdd attribute callback/observer on `vehicle` for `mode` attribute"     
-vehicle.on_attribute('mode', mode_callback)    
+vehicle.add_attribute_listener('mode', mode_callback)    
 
 
 print " Set mode=STABILIZE (currently: %s)" % vehicle.mode.name 
@@ -121,7 +121,7 @@ print " Wait 2s so callback invoked before observer removed"
 time.sleep(2)
 
 print " Remove Vehicle.mode observer"    
-# Remove observer added with `on_attribute()`  - specifying the attribute and callback function
+# Remove observer added with `add_attribute_listener()`  - specifying the attribute and callback function
 vehicle.remove_attribute_listener('mode', mode_callback)
 
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -105,13 +105,14 @@ while not vehicle.armed:
 
 
 # Add and remove and attribute callbacks (using mode as example)     
-def mode_callback(self, attr_name):
+def mode_callback(self, attr_name, value):
     # `attr_name` is the observed attribute (used if callback is used for multiple attributes)
-    # `self` is the associated vehicle object (used if callback behaviouris different for multiple vehicles)
-    print " CALLBACK: Mode changed to", self.mode
+    # `attr_name` - the observed attribute (used if callback is used for multiple attributes)
+    # `value` is the updated attribute value.
+    print " CALLBACK: Mode changed to", value
 
 print "\nAdd attribute callback/observer on `vehicle` for `mode` attribute"     
-vehicle.add_attribute_listener('mode', mode_callback)    
+vehicle.add_attribute_listener('mode', mode_callback)
 
 
 print " Set mode=STABILIZE (currently: %s)" % vehicle.mode.name 
@@ -124,6 +125,57 @@ print " Remove Vehicle.mode observer"
 # Remove observer added with `add_attribute_listener()`  - specifying the attribute and callback function
 vehicle.remove_attribute_listener('mode', mode_callback)
 
+
+                
+# Add mode attribute callback using decorator (callbacks added this way cannot be removed).
+print "\nAdd attribute callback/observer `mode` attribute using decorator" 
+last_published_mode=''
+@vehicle.on_attribute('mode')
+def mode_decorated_callback(self, attr_name, value):
+    # `attr_name` - the observed attribute (used if callback is used for multiple attributes)
+    # `self` - the associated vehicle object (used if a callback is different for multiple vehicles)
+    # `value` is the updated attribute value.
+    global last_published_mode
+    # Only publish when mode changes
+    if value!=last_published_mode:
+        print " CALLBACK: Mode changed to", value
+        last_published_mode=value
+
+
+print " Set mode=GUIDED (currently: %s)" % vehicle.mode.name 
+vehicle.mode = VehicleMode("GUIDED")
+
+print " Wait 2s so callback invoked before observer removed"
+time.sleep(2)
+
+print "\n Attempt to remove observer added with `on_attribute` decorator (should fail)" 
+try:
+    vehicle.remove_attribute_listener('mode', mode_decorated_callback)
+except:
+    print " Exception: Cannot add observer added using decorator"
+
+
+ 
+# Demonstrate getting callback on any attribute change
+def wildcard_callback(self, attr_name, value):
+    # `attr_name` - attribute name (useful if callback is used for multiple attributes)
+    # `self` - associated vehicle object (used if callback behaviour is different for multiple vehicles)
+    # `value` - updated attribute value.
+    print " CALLBACK: (%s): %s" % (attr_name,value)
+
+print "\nAdd attribute calback detecting any attribute change"     
+vehicle.add_attribute_listener('*', wildcard_callback)
+
+
+print " Wait 1s so callback invoked before observer removed"
+time.sleep(1)
+
+print " Remove Vehicle attribute observer"    
+# Remove observer added with `add_attribute_listener()`
+vehicle.remove_attribute_listener('*', wildcard_callback)
+    
+    
+    
 
 # Get/Set Vehicle Parameters
 print "\nRead vehicle param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']


### PR DESCRIPTION
Renames some things late in the game:

* renames `on_attribute` to `add_attribute_listener`
* renames `on_message` to `add_message_listener`
* renames `attribute_listener` to `on_attribute`
* renames `message_listener` to `on_message`

This creates more parity between `add_attribute_listener` and `remove_attribute_listener`, which attach and remove functions, and the simple shorthand / decorate `on_attribute` which would be pretty difficult to remove.

* Make `notify_attribute_listeners` and `notify_message_listeners` public

As per request.

* Pass attribute value into attribute listener.

See #61. Function prototype is now: `def listener(vehicle, attr_name, value)`