### PR TITLE
Supports cached home_location, replaces default 0,0,0 location with None.

### DIFF
--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -71,10 +71,15 @@ On the command prompt you should see (something like):
      Heading: 341
      Mode: STABILIZE
      Armed: False
-     Home Location: LocationGlobal:lat=-35.3632392883,lon=149.165237427,alt=222.0,is_relative=False
+     Waiting for home location ...
+     ...
+     Waiting for home location ...
+
+     Home location: LocationGlobal:lat=-35.3632621765,lon=149.165237427,alt=583.989990234,is_relative=False
 
     Set new home location
-     New Home Location (altitude should be 222): LocationGlobal:lat=-35.3632354736,lon=149.165237427,alt=222.0,is_relative=False
+     New Home Location (from attribute - altitude should be 222): LocationGlobal:lat=-35.363261,lon=149.1652299,alt=222,is_relative=False
+     New Home Location (from vehicle - altitude should be 222): LocationGlobal:lat=-35.3632621765,lon=149.165237427,alt=222.0,is_relative=False
 
     Set Vehicle.mode=GUIDED (currently: STABILIZE)
      Waiting for mode change ...

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -238,7 +238,8 @@ waypoints is set relative to this position.
 
 :py:attr:`Vehicle.home_location <dronekit.lib.Vehicle.home_location>` has the following behaviour:
 
-* In order to *get* the current value you must first download :py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>`, as shown:
+* In order to *get* the current value (in a :py:class:`LocationGlobal <dronekit.lib.LocationGlobal>` object) you must first download 
+  :py:attr:`Vehicle.commands <dronekit.lib.Vehicle.commands>`, as shown:
 
   .. code:: python
     
@@ -247,9 +248,21 @@ waypoints is set relative to this position.
       cmds.wait_ready()
       print " Home Location: %s" % vehicle.home_location
 
-  The returned value is a :py:class:`LocationGlobal <dronekit.lib.LocationGlobal>` object 
-  (or ``None`` before you download the commands). If the location has not been set, then 
-  the returned value's attributes will all be set to zero.
+  The returned value is ``None`` before you download the commands or if the ``home_location`` has not yet been set by the autopilot.
+  For this reason our example code checks that the value exists (in a loop) before writing it.
+  
+  .. code:: python
+    
+      # Get Vehicle Home location - will be `None` until first set by autopilot
+      while not vehicle.home_location:
+          cmds = vehicle.commands
+          cmds.download()
+          cmds.wait_ready()
+          if not vehicle.home_location:
+              print " Waiting for home location ..."
+              
+      # We have a home location.     
+      print "\n Home location: %s" % vehicle.home_location
 
 * The attribute can be *set* to a :py:class:`LocationGlobal <dronekit.lib.LocationGlobal>` object 
   (the code fragment below sets it to the current location):
@@ -260,9 +273,11 @@ waypoints is set relative to this position.
         
   There are some caveats:
   
-  * You must download the commands again to read the changed ``home_location``.
-  * The autopilot must first set the value (on startup) before it can be changed by DroneKit-Python code.
+  * You must be able to read a non-``None`` value before you can write it
+    (the autopilot has to set the value initially before it can be written or read).
   * The new location must be within 50 km of the EKF origin or setting the value will silently fail.
+  * The value is cached in the ``home_location``. If the variable can potentially change on the vehicle
+    you will need to re-download the ``Vehicle.commands`` in order to confirm the value.
     
 * The attribute is not observable.
 

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -1123,12 +1123,11 @@ class Vehicle(HasObservers):
     @property
     def home_location(self):
         """
-        The current home location in a :py:class:`LocationGlobal`. 
+        The current home location in a :py:class:`LocationGlobal`.
 
-        This value is initially set by the autopilot as the location of first GPS Lock.
-        The attribute has a value of ``None`` until :py:func:`Vehicle.commands` has been downloaded. 
-        If the attribute is queried before the home location is set the returned `LocationGlobal` 
-        will have zero values for its member attributes.
+        To get the attribute you must first download the :py:func:`Vehicle.commands`. 
+        The attribute has a value of ``None`` until :py:func:`Vehicle.commands` has been downloaded
+        **and** the autopilot has set an initial home location (typically where the vehicle first gets GPS lock).
 
         .. code-block:: python
 
@@ -1143,7 +1142,16 @@ class Vehicle(HasObservers):
             # Get the home location
             home = vehicle.home_location
 
-        The attribute is not writeable or observable.
+        The ``home_location`` is not observable.
+        
+        The attribute can be written (in the same way as any other attribute) after it has successfully 
+        been populated from the vehicle. The value sent to the vehicle is cached in the attribute 
+        (and can potentially get out of date if you don't re-download ``Vehicle.commands``):
+
+        .. warning:: 
+
+            Setting the value will fail silently if the specified location is more than 50km from the EKF origin.
+        
 
         """
         return copy.copy(self._home_location)
@@ -1152,10 +1160,13 @@ class Vehicle(HasObservers):
     def home_location(self, pos):
         """
         Sets the home location to that of a ``LocationGlobal`` object.
+        
+        The value cannot be set until it has successfully been read from the vehicle. After being
+        set the value is cached in the home_location attribute and does not have to be re-read.
 
         .. note:: 
 
-            If the GPS values differ heavily from EKF values, setting this value will fail silently.
+            Setting the value will fail silently if the specified location is more than 50km from the EKF origin.
         """
 
         if not isinstance(pos, LocationGlobal):

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -52,38 +52,31 @@ print " Mode: %s" % vehicle.mode.name    # settable
 print " Armed: %s" % vehicle.armed    # settable
 
 
-# Get Vehicle Home location 
-#   Note: home_location attributes will be 0.0 if the autopilot has not yet set the home location.
-cmds = vehicle.commands
-cmds.download()
-cmds.wait_ready()
-print " Home Location: %s" % vehicle.home_location
-
-
-# Set vehicle home_location, mode, and armed attributes (the only settable attributes)
-print "\nSet new home location"
-
-# Home location must first have been set by the autopilot before we can set it.
-while vehicle.home_location.lat == 0.0:
+# Get Vehicle Home location - will be `None` until first set by autopilot
+while not vehicle.home_location:
     cmds = vehicle.commands
     cmds.download()
     cmds.wait_ready()
-    if vehicle.home_location.lat == 0.0:
-        print " Waiting for home location: %s" % vehicle.home_location
-    else:
-        print "\n Autopilot set home location: %s" % vehicle.home_location
-    
+    if not vehicle.home_location:
+        print " Waiting for home location ..."
+# We have a home location, so print it!        
+print "\n Home location: %s" % vehicle.home_location
+
+# Set vehicle home_location, mode, and armed attributes (the only settable attributes)
+
+print "\nSet new home location"
 # Home location must be within 50km of EKF home location (or setting will fail silently)
 # In this case, just set value to current location with an easily recognisable altitude (222)
 my_location_alt=vehicle.location.global_frame
 my_location_alt.alt=222
 vehicle.home_location=my_location_alt
+print " New Home Location (from attribute - altitude should be 222): %s" % vehicle.home_location
 
 #Confirm it is written out (note that you must re-download commands)
 cmds = vehicle.commands
 cmds.download()
 cmds.wait_ready()
-print " New Home Location (altitude should be 222): %s" % vehicle.home_location
+print " New Home Location (from vehicle - altitude should be 222): %s" % vehicle.home_location
 
 
 print "\nSet Vehicle.mode=GUIDED (currently: %s)" % vehicle.mode.name 


### PR DESCRIPTION
* home_location, on setting, now caches value until actual change is set.
* 0,0,0 home location tuple is now ignored. `home_location` will read None until a valid value is read.