### PR TITLE
Updates Create Attribute example.

### DIFF
--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -4,10 +4,13 @@
 Example: Create Attribute in App
 ================================
 
-This example shows how you can create attributes for MAVLink messages within your DroneKit-Python script and 
-use them in *in the same way* as the built-in :py:class:`Vehicle <dronekit.lib.Vehicle>` attributes.
+This example shows how you can subclass :py:class:`Vehicle <dronekit.lib.Vehicle>` in order to support 
+new attributes for MAVLink messages within your DroneKit-Python script. The new class is defined in a 
+separate file (making re-use easy) and is very similar to the code used to implement the in-built attributes. 
+The new attributes are used *in the same way* as the built-in 
+:py:class:`Vehicle <dronekit.lib.Vehicle>` attributes.
 
-It uses the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator
+The new class uses the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` decorator
 to set a function that is called to process a specific message, copy its values into an attribute, and notify
 observers. An observer is then set on the new attribute using 
 :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>`.
@@ -15,7 +18,7 @@ observers. An observer is then set on the new attribute using
 Additional information is provided in the guide topic :ref:`mavlink_messages`.
 
 .. tip::
-       
+    
     This approach is useful when you urgently need to access messages that are not yet supported as 
     :py:class:`Vehicle <dronekit.lib.Vehicle>` attributes.
 
@@ -86,9 +89,20 @@ On the command prompt you should see (something like):
 How does it work?
 =================
 
-The example first defines a class for the attribute. This has members for each of the values in the message
-(in this case `RAW_IMU <http://mavlink.org/messages/common#RAW_IMU>`_). It provides an initialiser and a string 
-representation for printing the object.
+Subclassing Vehicle
+-------------------
+
+The example file **my_vehicle.py** defines a class for the new attribute (``RawIMU``) and a new vehicle subclass (``MyVehicle``).
+
+.. note::
+
+    The example uses the same documentation markup used by the native code, which can be generated into a document set using
+    Sphinx/autodoc.
+
+
+``RawIMU`` has members for each of the values in the message
+(in this case `RAW_IMU <http://mavlink.org/messages/common#RAW_IMU>`_). It provides an initialiser that sets all the values to
+``None`` and a string representation for printing the object.
 
 .. code:: python
 
@@ -132,63 +146,97 @@ representation for printing the object.
             """
             return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc, self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
 
-The script should then create an instance of the class and add it as an attribute to the vehicle object retrieved from the connection.
-All values in the new attribute should be set to ``None`` so that it is obvious to users when no messages have been received. 
 
-.. code:: python
+``MyVehicle`` is a superclass of ``Vehicle`` (and hence inherits all its attributes). 
+This first creates a private instance of ``RawIMU``.
 
-    # Connect to the Vehicle passed in as args.connect
-    vehicle = connect(args.connect, wait_ready=True)
-
-    #Create an Vehicle.raw_imu object with values set to `None`.
-    vehicle.raw_imu=RawIMU()
-    
 We create a listener using the :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` 
-decorator as shown below. The listener is called for messages that contain the string "RAW_IMU", 
+decorator. The listener is called for messages that contain the string "RAW_IMU", 
 with arguments for the vehicle, message name, and the message. It copies the message information into 
 the attribute and then notifies all observers.
 
-.. code:: python
 
-    #Create a message listener using the decorator.   
-    @vehicle.on_message('RAW_IMU')
-    def listener(self, name, message):
-        #Copy the message contents into the raw_imu attribute
-        self.raw_imu.time_boot_us=message.time_usec
-        self.raw_imu.xacc=message.xacc
-        self.raw_imu.yacc=message.yacc
-        self.raw_imu.zacc=message.zacc
-        self.raw_imu.xgyro=message.xgyro
-        self.raw_imu.ygyro=message.ygyro
-        self.raw_imu.zgyro=message.zgyro
-        self.raw_imu.xmag=message.xmag
-        self.raw_imu.ymag=message.ymag
-        self.raw_imu.zmag=message.zmag
-        
-        # Notify all observers of new message with new value
-        self.notify_attribute_listeners('raw_imu', self.raw_imu) 
+.. code-block:: python
+    :emphasize-lines: 6, 9-10, 30
+                
+    class MyVehicle(Vehicle):
+        def __init__(self, *args):
+            super(MyVehicle, self).__init__(*args)
 
+            # Create an Vehicle.raw_imu object with initial values set to None.
+            self._raw_imu = RawIMU()
+
+            # Create a message listener using the decorator.   
+            @self.on_message('RAW_IMU')
+            def listener(self, name, message):
+                """
+                The listener is called for messages that contain the string specified in the decorator,
+                passing the vehicle, message name, and the message.
+                
+                The listener writes the message to the (newly attached) ``vehicle.raw_imu`` object 
+                and notifies observers.
+                """
+                self._raw_imu.time_boot_us=message.time_usec
+                self._raw_imu.xacc=message.xacc
+                self._raw_imu.yacc=message.yacc
+                self._raw_imu.zacc=message.zacc
+                self._raw_imu.xgyro=message.xgyro
+                self._raw_imu.ygyro=message.ygyro
+                self._raw_imu.zgyro=message.zgyro
+                self._raw_imu.xmag=message.xmag
+                self._raw_imu.ymag=message.ymag
+                self._raw_imu.zmag=message.zmag
+                
+                # Notify all observers of new message (with new value)
+                self.notify_attribute_listeners('raw_imu', self._raw_imu) 
+
+        @property
+        def raw_imu(self):
+            return self._raw_imu            
+            
+At the end of the class we create the public properly ``raw_imu`` which client code may read and observe.
 
 .. note:: 
 
     The decorator pattern means that you can have multiple listeners for a particular message or for different
     messages and they can all have the same function name/prototype (in this case ``listener(self, name, message``).
 
-        
-From this point the ``Vehicle.raw_imu`` attribute can be treated the same as any other (inbuilt) attribute.
-You can query the attribute to get any of its members, and even add an observer as shown:
 
+Using the Vehicle subclass
+--------------------------
+
+The **create_attribute.py** file first imports the ``MyVehicle`` class. 
+
+
+.. code-block:: python
+    :emphasize-lines: 2
+
+    from dronekit import connect, Vehicle
+    from my_vehicle import MyVehicle #Our custom vehicle class
+    import time
+
+
+We then call ``connect()``, specifying this new class in the ``vehicle_class`` argument.    
+    
+.. code-block:: python
+
+    # Connect to our custom vehicle_class `MyVehicle` at address `args.connect`
+    vehicle = connect(args.connect, wait_ready=True, vehicle_class=MyVehicle)  
+    
+``connect()`` returns a ``MyVehicle`` class which can be used in *exactly the same way* as ``Vehicle`` but with an 
+additional attribute ``raw_imu``. You can query the attribute to get any of its members, and even add an observer as shown:
 
 .. code:: python
 
-    #Callback to print the raw_imu
-    def raw_imu_callback(self, attr_name, msg):
-        #msg is the value/attribute that was updated.
-        print msg
+    # Add observer for the custom attribute
 
+    def raw_imu_callback(self, attr_name, value):
+        # attr_name == 'raw_imu'
+        # value == vehicle.raw_imu
+        print value
 
-    #Add observer for the vehicle's current location
     vehicle.add_attribute_listener('raw_imu', raw_imu_callback)
+
 
 
 Known issues
@@ -205,3 +253,5 @@ The full source code at documentation build-time is listed below (`current versi
 .. literalinclude:: ../../examples/create_attribute/create_attribute.py
    :language: python
 
+.. literalinclude:: ../../examples/create_attribute/my_vehicle.py
+   :language: python

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -10,10 +10,10 @@ intercepted using the message_listener decorator.
 Full documentation is provided at http://python.dronekit.io/examples/create_attribute.html
 """
 
-from dronekit import connect
-from dronekit.lib import VehicleMode
+from dronekit import connect, Vehicle, VehicleMode
 from pymavlink import mavutil
 import time
+from my_vehicle import MyVehicle
 
 
 #Set up option parsing to get connection string
@@ -23,101 +23,23 @@ parser.add_argument('--connect', default='127.0.0.1:14550',
                    help="vehicle connection target. Default '127.0.0.1:14550'")
 args = parser.parse_args()
 
-
-# Connect to the Vehicle
+# Connect to our custom vehicle_class MyVehicle
 print 'Connecting to vehicle on: %s' % args.connect
-vehicle = connect(args.connect, wait_ready=True)
+vehicle = connect(args.connect, wait_ready=True, vehicle_class=MyVehicle)
 
+# Add observer for the custom attribute
 
-class RawIMU(object):
-    """
-    The RAW IMU readings for the usual 9DOF sensor setup. 
-    This contains the true raw values without any scaling to allow data capture and system debugging.
-    
-    The message definition is here: https://pixhawk.ethz.ch/mavlink/#RAW_IMU
-    
-    :param time_boot_us: Timestamp (microseconds since system boot). #Note, not milliseconds as per spec
-    :param xacc: X acceleration (mg)
-    :param yacc: Y acceleration (mg)
-    :param zacc: Z acceleration (mg)
-    :param xgyro: Angular speed around X axis (millirad /sec)
-    :param ygyro: Angular speed around Y axis (millirad /sec)
-    :param zgyro: Angular speed around Z axis (millirad /sec)
-    :param xmag: X Magnetic field (milli tesla)
-    :param ymag: Y Magnetic field (milli tesla)
-    :param zmag: Z Magnetic field (milli tesla)    
-    """
-    def __init__(self, time_boot_us=None, xacc=None, yacc=None, zacc=None, xygro=None, ygyro=None, zgyro=None, xmag=None, ymag=None, zmag=None):
-        """
-        RawIMU object constructor.
-        """
-        self.time_boot_us = time_boot_us
-        self.xacc = xacc
-        self.yacc = yacc
-        self.zacc = zacc
-        self.xgyro = zgyro
-        self.ygyro = ygyro
-        self.zgyro = zgyro
-        self.xmag = xmag        
-        self.ymag = ymag
-        self.zmag = zmag      
-        
-    def __str__(self):
-        """
-        String representation used to print the RawIMU object. 
-        """
-        return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc, self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
+def raw_imu_callback(self, attr_name, value):
+    # attr_name == 'raw_imu'
+    # value == vehicle.raw_imu
+    print value
 
-   
-
-#Create an Vehicle.raw_imu object with initial values set to None.
-vehicle.raw_imu=RawIMU()
- 
-
-
-#Create a message listener using the decorator.   
-@vehicle.on_message('RAW_IMU')
-def listener(self, name, message):
-    """
-    The listener is called for messages that contain the string specified in the decorator,
-    passing the vehicle, message name, and the message.
-    
-    The listener writes the message to the (newly attached) ``vehicle.raw_imu`` object 
-    and notifies observers.
-    """
-    self.raw_imu.time_boot_us=message.time_usec
-    self.raw_imu.xacc=message.xacc
-    self.raw_imu.yacc=message.yacc
-    self.raw_imu.zacc=message.zacc
-    self.raw_imu.xgyro=message.xgyro
-    self.raw_imu.ygyro=message.ygyro
-    self.raw_imu.zgyro=message.zgyro
-    self.raw_imu.xmag=message.xmag
-    self.raw_imu.ymag=message.ymag
-    self.raw_imu.zmag=message.zmag
-    
-    # Notify all observers of new message (with new value)
-    self.notify_attribute_listeners('raw_imu', self.raw_imu) 
-    
-
-"""
-From this point vehicle.raw_imu can be used just like any other attribute.
-"""
-
-#Callback to print the raw_imu
-def raw_imu_callback(self,attr_name,msg):
-    #msg is the attribute/value that changed
-    print msg
-
-
-#Add observer for the vehicle's current location
 vehicle.add_attribute_listener('raw_imu', raw_imu_callback)
 
 print 'Display RAW_IMU messages for 5 seconds and then exit.'
 time.sleep(5)
 
 #The message listener can be unset using ``vehicle.remove_message_listener``
-
 
 #Close vehicle object before exiting script
 print "Close vehicle object"

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -10,10 +10,10 @@ intercepted using the message_listener decorator.
 Full documentation is provided at http://python.dronekit.io/examples/create_attribute.html
 """
 
-from dronekit import connect, Vehicle, VehicleMode
-from pymavlink import mavutil
+from dronekit import connect, Vehicle
+from my_vehicle import MyVehicle #Our custom vehicle class
 import time
-from my_vehicle import MyVehicle
+
 
 
 #Set up option parsing to get connection string

--- a/examples/create_attribute/my_vehicle.py
+++ b/examples/create_attribute/my_vehicle.py
@@ -1,0 +1,84 @@
+"""
+my_vehicle.py:
+
+Custom Vehicle subclass to add IMU data.
+"""
+
+from dronekit import connect, Vehicle, VehicleMode
+from pymavlink import mavutil
+import time
+
+class RawIMU(object):
+    """
+    The RAW IMU readings for the usual 9DOF sensor setup. 
+    This contains the true raw values without any scaling to allow data capture and system debugging.
+    
+    The message definition is here: https://pixhawk.ethz.ch/mavlink/#RAW_IMU
+    
+    :param time_boot_us: Timestamp (microseconds since system boot). #Note, not milliseconds as per spec
+    :param xacc: X acceleration (mg)
+    :param yacc: Y acceleration (mg)
+    :param zacc: Z acceleration (mg)
+    :param xgyro: Angular speed around X axis (millirad /sec)
+    :param ygyro: Angular speed around Y axis (millirad /sec)
+    :param zgyro: Angular speed around Z axis (millirad /sec)
+    :param xmag: X Magnetic field (milli tesla)
+    :param ymag: Y Magnetic field (milli tesla)
+    :param zmag: Z Magnetic field (milli tesla)    
+    """
+    def __init__(self, time_boot_us=None, xacc=None, yacc=None, zacc=None, xygro=None, ygyro=None, zgyro=None, xmag=None, ymag=None, zmag=None):
+        """
+        RawIMU object constructor.
+        """
+        self.time_boot_us = time_boot_us
+        self.xacc = xacc
+        self.yacc = yacc
+        self.zacc = zacc
+        self.xgyro = zgyro
+        self.ygyro = ygyro
+        self.zgyro = zgyro
+        self.xmag = xmag        
+        self.ymag = ymag
+        self.zmag = zmag      
+        
+    def __str__(self):
+        """
+        String representation used to print the RawIMU object. 
+        """
+        return "RAW_IMU: time_boot_us={},xacc={},yacc={},zacc={},xgyro={},ygyro={},zgyro={},xmag={},ymag={},zmag={}".format(self.time_boot_us, self.xacc, self.yacc,self.zacc,self.xgyro,self.ygyro,self.zgyro,self.xmag,self.ymag,self.zmag)
+
+   
+class MyVehicle(Vehicle):
+    def __init__(self, *args):
+        super(MyVehicle, self).__init__(*args)
+
+        # Create an Vehicle.raw_imu object with initial values set to None.
+        self._raw_imu = RawIMU()
+
+        # Create a message listener using the decorator.   
+        @self.on_message('RAW_IMU')
+        def listener(self, name, message):
+            """
+            The listener is called for messages that contain the string specified in the decorator,
+            passing the vehicle, message name, and the message.
+            
+            The listener writes the message to the (newly attached) ``vehicle.raw_imu`` object 
+            and notifies observers.
+            """
+            self._raw_imu.time_boot_us=message.time_usec
+            self._raw_imu.xacc=message.xacc
+            self._raw_imu.yacc=message.yacc
+            self._raw_imu.zacc=message.zacc
+            self._raw_imu.xgyro=message.xgyro
+            self._raw_imu.ygyro=message.ygyro
+            self._raw_imu.zgyro=message.zgyro
+            self._raw_imu.xmag=message.xmag
+            self._raw_imu.ymag=message.ymag
+            self._raw_imu.zmag=message.zmag
+            
+            # Notify all observers of new message (with new value)
+            self.notify_attribute_listeners('raw_imu', self._raw_imu) 
+
+    @property
+    def raw_imu(self):
+        return self._raw_imu

--- a/examples/create_attribute/my_vehicle.py
+++ b/examples/create_attribute/my_vehicle.py
@@ -4,9 +4,8 @@ my_vehicle.py:
 Custom Vehicle subclass to add IMU data.
 """
 
-from dronekit import connect, Vehicle, VehicleMode
-from pymavlink import mavutil
-import time
+from dronekit import Vehicle
+
 
 class RawIMU(object):
     """


### PR DESCRIPTION
This addresses some of the questions brought up by #277 and #420.

The goal is "the correct way for users to implement custom attributes". I rewrote this example to leverage the vehicle_class property of connect to instantiate a custom Vehicle class. The Vehicle constructor works similarly to how the internal ones, allowing you to add private properties, message listeners, etc. that become part of the class definition.

I recommend this as the definitive way downstream users implement custom properties, as it's similar to how internal extensions like [dronekit-python-solo](https://github.com/dronekit/dronekit-python-solo) do it.