### PR TITLE
Implements SystemStatus property.

### DIFF
--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -68,7 +68,7 @@ On the command prompt you should see (something like):
      Rangefinder distance: None
      Rangefinder voltage: None
      Is Armable?: True
-     System status: 3
+     System status: STANDBY
      Heading: 341
      Mode: STABILIZE
      Armed: False

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -74,7 +74,7 @@ regularly updated from MAVLink messages sent by the vehicle).
     print "Rangefinder voltage: %s" % vehicle.rangefinder.voltage
     print "Heading: %s" % vehicle.heading
     print "Is Armable?: %s" % vehicle.is_armable
-    print "System status: %s" % vehicle.system_status
+    print "System status: %s" % vehicle.system_status.state
     print "Mode: %s" % vehicle.mode.name    # settable
     print "Armed: %s" % vehicle.armed    # settable
 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -22,6 +22,7 @@ Vehicle = dronekit.lib.Vehicle
 Command = dronekit.lib.Command
 CommandSequence = dronekit.lib.CommandSequence
 VehicleMode = dronekit.lib.VehicleMode
+SystemStatus = dronekit.lib.SystemStatus
 LocationGlobal = dronekit.lib.LocationGlobal
 LocationLocal = dronekit.lib.LocationLocal
 CloudClient = dronekit.lib.CloudClient

--- a/dronekit/test/sitl/test_state.py
+++ b/dronekit/test/sitl/test_state.py
@@ -1,0 +1,14 @@
+import time
+import sys
+import os
+import socket
+from dronekit import connect, VehicleMode, SystemStatus
+from dronekit.test import with_sitl
+from nose.tools import assert_equals
+
+@with_sitl
+def test_state(connpath):
+    vehicle = connect(connpath, wait_ready=['system_status'])
+
+    assert_equals(type(vehicle.system_status), SystemStatus)
+    assert_equals(type(vehicle.system_status.state), str)

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -48,7 +48,7 @@ print " Rangefinder distance: %s" % vehicle.rangefinder.distance
 print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
 print " Heading: %s" % vehicle.heading
 print " Is Armable?: %s" % vehicle.is_armable
-print " System status: %s" % vehicle.system_status
+print " System status: %s" % vehicle.system_status.state
 print " Mode: %s" % vehicle.mode.name    # settable
 print " Armed: %s" % vehicle.armed    # settable
 


### PR DESCRIPTION
Replaces #156.

This adds a `SystemStatus` property which functions similarly to `VehicleMode`, in that it is a light wrapper around a string (really an enum).

This is a breaking change with earlier rc's in that it used to be a number from mavutil, and is no longer.