### PR TITLE
Memoize attribute listeners to not call them on equal values.

### DIFF
--- a/docs/examples/create_attribute.rst
+++ b/docs/examples/create_attribute.rst
@@ -155,9 +155,8 @@ decorator. The listener is called for messages that contain the string "RAW_IMU"
 with arguments for the vehicle, message name, and the message. It copies the message information into 
 the attribute and then notifies all observers.
 
-
 .. code-block:: python
-    :emphasize-lines: 6, 9-10, 30
+    :emphasize-lines: 6, 9-10, 32
                 
     class MyVehicle(Vehicle):
         def __init__(self, *args):
@@ -188,12 +187,28 @@ the attribute and then notifies all observers.
                 self._raw_imu.zmag=message.zmag
                 
                 # Notify all observers of new message (with new value)
+                #   Note that argument `cache=False` by default so listeners
+                #   are updaed with every new message
                 self.notify_attribute_listeners('raw_imu', self._raw_imu) 
 
         @property
         def raw_imu(self):
             return self._raw_imu            
-            
+
+
+.. note::
+
+    The notifier function (:py:func:`Vehicle.notify_attribute_listeners() <dronekit.lib.Vehicle.notify_attribute_listeners>`)
+    should be called every time there is an update from the vehicle. 
+    
+    You can set a third parameter (``cache=True``) so that it only invokes the listeners when the value *changes*. 
+    This is normally used for vehicle state information like ``Vehicle.mode``, where the value is updated 
+    regularly from the vehicle client code is only interested in attribute changes.
+    
+    You should not set ``cache=True`` for attributes that represent sensor information or other "live" information, including
+    the RAW_IMU attribute demonstrated here. Clients can then implement their own caching strategy if needed.
+
+
 At the end of the class we create the public properly ``raw_imu`` which client code may read and observe.
 
 .. note:: 

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -97,10 +97,13 @@ On the command prompt you should see (something like):
      CALLBACK: Mode changed to VehicleMode:STABILIZE
      Remove Vehicle.mode observer
 
-    Add attribute callback/observer `mode` attribute using decorator
-     Set mode=GUIDED (currently: STABILIZE)
+    Add attribute callback/observer on `attitude` attribute using decorator
      Wait 2s so callback invoked before observer removed
-     CALLBACK: Mode changed to VehicleMode:GUIDED
+     CALLBACK: Location changed to Attitude:pitch=0.0062674083747,yaw=-0.0318436846137,roll=-0.00923461187631
+     CALLBACK: Location changed to Attitude:pitch=0.00625518895686,yaw=-0.0317140743136,roll=-0.0091759338975
+     ...
+     CALLBACK: Location changed to Attitude:pitch=0.00629614247009,yaw=-0.0343224518001,roll=-0.0108289364725
+     CALLBACK: Location changed to Attitude:pitch=0.00636938679963,yaw=-0.0352342799306,roll=-0.01096534729
 
      Attempt to remove observer added with `on_attribute` decorator (should fail)
      Exception: Cannot add observer added using decorator

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -196,8 +196,21 @@ the vehicle.
 
 The difference between :py:func:`Vehicle.add_attribute_listener() <dronekit.lib.Vehicle.add_attribute_listener>` and 
 :py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` is that attribute listeners added using
-:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` cannot be removed (but ``on_attribute()`` does have
-a more elegant syntax).
+:py:func:`Vehicle.on_attribute() <dronekit.lib.Vehicle.on_attribute>` cannot be removed (while ``on_attribute()`` 
+has a more elegant syntax).
+
+A few attributes have been modified so that they only notify when the value changes: 
+:py:func:`Vehicle.system_status <dronekit.lib.Vehicle.system_status>`,
+:py:attr:`Vehicle.armed <dronekit.lib.Vehicle.armed>`, and
+:py:attr:`Vehicle.mode <dronekit.lib.Vehicle.mode>`. Users no longer need to add caching code 
+for these attributes in their listeners.
+Attributes that provide "streams" of information (i.e. sensor output) remain unchanged. 
+
+.. note::
+
+    If you're :ref:`creating your own attributes <example_create_attribute>` this caching is trivially 
+    provided using the ``cache=True`` argument to 
+    :py:func:`Vehicle.notify_attribute_listeners() <dronekit.lib.Vehicle.notify_attribute_listeners>`.
 
 See :ref:`vehicle_state_observe_attributes` for more information.
 
@@ -220,7 +233,7 @@ decorator, which allows you to specify a callback function that will be invoked 
     The API also adds :py:func:`Vehicle.add_message_listener() <dronekit.lib.Vehicle.add_message_listener>`
     and :py:func:`Vehicle.remove_message_listener() <dronekit.lib.Vehicle.remove_message_listener>`. 
     These can be used instead of :py:func:`Vehicle.on_message() <dronekit.lib.Vehicle.on_message>` when you need to be
-    able to *remove* an added listener.
+    able to *remove* an added listener. Typically you won't need to!
 
 See :ref:`mavlink_messages` for more information.
 

--- a/dronekit/test/sitl/test_110.py
+++ b/dronekit/test/sitl/test_110.py
@@ -14,9 +14,13 @@ def test_110(connpath):
     # exclusively for simulation. Take heed!!!
     vehicle.parameters['FS_GCS_ENABLE'] = 0
     vehicle.parameters['FS_EKF_THRESH'] = 100
+
+    # Await armability.
+    while not vehicle.is_armable:
+        time.sleep(.1)
     
     # Change the vehicle into STABILIZE mode
-    vehicle.mode = VehicleMode("STABILIZE")
+    vehicle.mode = VehicleMode("GUIDED")
 
     # NOTE wait crudely for ACK on mode update
     time.sleep(3)
@@ -34,8 +38,8 @@ def test_110(connpath):
     vehicle.add_attribute_listener('armed', armed_callback)
     vehicle.add_attribute_listener('armed', armed_callback)
 
-    # Disarm and see update.
-    vehicle.armed = False
+    # arm and see update.
+    vehicle.armed = True
     # Wait for ACK.
     time.sleep(3)
 
@@ -51,8 +55,8 @@ def test_110(connpath):
     vehicle.remove_attribute_listener('armed', armed_callback)
     callcount = armed_callback.called
 
-    # Re-arm and see update.
-    vehicle.armed = True
+    # Disarm and see update.
+    vehicle.armed = False
     # Wait for ack
     time.sleep(3)
 

--- a/examples/create_attribute/my_vehicle.py
+++ b/examples/create_attribute/my_vehicle.py
@@ -76,6 +76,8 @@ class MyVehicle(Vehicle):
             self._raw_imu.zmag=message.zmag
             
             # Notify all observers of new message (with new value)
+            #   Note that argument `cache=False` by default so listeners
+            #   are updaed with every new message
             self.notify_attribute_listeners('raw_imu', self._raw_imu) 
 
     @property

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -133,9 +133,9 @@ def decorated_attitude_callback(self, attr_name, value):
     # `self` - the associated vehicle object (used if a callback is different for multiple vehicles)
     # `value` is the updated attribute value.
     global last_attitude_cache
-    # Only publish when mode changes
+    # Only publish when value changes
     if value!=last_attitude_cache:
-        print " CALLBACK: Location changed to", value
+        print " CALLBACK: Attitude changed to", value
         last_attitude_cache=value
 
 
@@ -144,9 +144,9 @@ time.sleep(2)
 
 print "\n Attempt to remove observer added with `on_attribute` decorator (should fail)" 
 try:
-    vehicle.remove_attribute_listener('mode', mode_decorated_callback)
+    vehicle.remove_attribute_listener('mode', decorated_attitude_callback)
 except:
-    print " Exception: Cannot add observer added using decorator"
+    print " Exception: Cannot remove observer added using decorator"
 
 
  

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -124,23 +124,20 @@ vehicle.remove_attribute_listener('mode', mode_callback)
 
 
                 
-# Add mode attribute callback using decorator (callbacks added this way cannot be removed).
-print "\nAdd attribute callback/observer `mode` attribute using decorator" 
-last_published_mode=''
-@vehicle.on_attribute('mode')
-def mode_decorated_callback(self, attr_name, value):
+# Add attitude attribute callback using decorator (callbacks added this way cannot be removed).
+print "\nAdd attribute callback/observer on `attitude` attribute using decorator" 
+last_attitude_cache=None
+@vehicle.on_attribute('attitude')
+def decorated_attitude_callback(self, attr_name, value):
     # `attr_name` - the observed attribute (used if callback is used for multiple attributes)
     # `self` - the associated vehicle object (used if a callback is different for multiple vehicles)
     # `value` is the updated attribute value.
-    global last_published_mode
+    global last_attitude_cache
     # Only publish when mode changes
-    if value!=last_published_mode:
-        print " CALLBACK: Mode changed to", value
-        last_published_mode=value
+    if value!=last_attitude_cache:
+        print " CALLBACK: Location changed to", value
+        last_attitude_cache=value
 
-
-print " Set mode=GUIDED (currently: %s)" % vehicle.mode.name 
-vehicle.mode = VehicleMode("GUIDED")
 
 print " Wait 2s so callback invoked before observer removed"
 time.sleep(2)


### PR DESCRIPTION
See #60. Memoization seemed like the "cheapest" approach: not up to the end user to maintain state and observe changes, instead, implemented at the level of attribute listening.