### PR TITLE
Implements target_system lookup. Implements better target semantics.

### DIFF
--- a/docs/guide/copter/guided_mode.rst
+++ b/docs/guide/copter/guided_mode.rst
@@ -199,11 +199,12 @@ message fields as arguments:
     # send command to vehicle
     vehicle.send_mavlink(msg)
 
-There is no need to specify the ``target_system`` id in messages (just set to zero) as DroneKit will automatically 
-update messages with the vehicle's internal ``target_system`` (see :py:func:`connect() <dronekit.lib.connect>`) before sending. 
-The ``target_component`` should be set to 0 (broadcast) unless the message is to specific component. 
-CRC fields and sequence numbers (if defined in the message type) are automatically set by DroneKit and can also 
-be ignored/set to zero.
+If a message includes ``target_system`` id you can set it to zero (DroneKit will automatically 
+update the value with the correct ID for the connected vehicle). Similarly CRC fields and sequence numbers 
+(if defined in the message type) can be set to zero as they are automatically updated by DroneKit.
+The ``target_component`` is not updated by DroneKit, but should be set to 0 (broadcast) unless the message is 
+really intended for a specific component. 
+
 
 .. _guided_mode_how_to_send_commands_command_long:
 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -25,8 +25,8 @@ LocationGlobal = dronekit.lib.LocationGlobal
 LocationLocal = dronekit.lib.LocationLocal
 CloudClient = dronekit.lib.CloudClient
 
-def connect(ip, _initialize=True, wait_ready=None, status_printer=errprinter, vehicle_class=Vehicle, rate=4, baud=115200, heartbeat_timeout=30, target_system=0):
-    handler = MAVConnection(ip, baud=baud, target_system=target_system)
+def connect(ip, _initialize=True, wait_ready=None, status_printer=errprinter, vehicle_class=Vehicle, rate=4, baud=115200, heartbeat_timeout=30, source_system=255):
+    handler = MAVConnection(ip, baud=baud, source_system=source_system)
     vehicle = vehicle_class(handler)
 
     if status_printer:

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -64,7 +64,7 @@ A number of other useful classes and methods are listed below.
     :param int rate: Data stream refresh rate. The default is 4Hz (4 updates per second).
     :param int baud: The baud rate for the connection. The default is 115200.
     :param int heartbeat_timeout: Connection timeout value in seconds (default is 30s). 
-        If a heartbeat is not detected up within this time an exception will be raised.    
+        If a heartbeat is not detected within this time an exception will be raised.    
     :param int source_system: The MAVLink ID of the :py:class:`Vehicle` object returned by this method (by default 255).
 
         .. note::

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -1102,6 +1102,7 @@ class Vehicle(HasObservers):
 
         self._heartbeat_warning = 5
         self._heartbeat_error = 30
+        self._heartbeat_system = None
 
         @handler.forward_loop
         def listener(_):
@@ -1121,6 +1122,7 @@ class Vehicle(HasObservers):
 
         @self.on_message(['HEARTBEAT'])
         def listener(self, name, msg):
+            self._heartbeat_system = msg.get_srcSystem()
             self._heartbeat_lastreceived = time.time()
             if self._heartbeat_timeout:
                 errprinter('>>> ...link restored.')
@@ -1613,6 +1615,9 @@ class Vehicle(HasObservers):
                 break
         if not self._handler._alive:
             raise APIException('Timeout in initializing connection.')
+
+        # Register target_system now.
+        self._handler.target_system = self._heartbeat_system
 
         # Wait until board has booted.
         while True:

--- a/dronekit/lib/__init__.py
+++ b/dronekit/lib/__init__.py
@@ -64,7 +64,7 @@ A number of other useful classes and methods are listed below.
     :param int rate: Data stream refresh rate. The default is 4Hz (4 updates per second).
     :param int baud: The baud rate for the connection. The default is 115200.
     :param int heartbeat_timeout: Connection timeout value in seconds (default is 30s). 
-        If a link is not set up within this time, an exception will be raised.    
+        If a heartbeat is not detected up within this time an exception will be raised.    
     :param int source_system: The MAVLink ID of the :py:class:`Vehicle` object returned by this method (by default 255).
 
         .. note::


### PR DESCRIPTION
Exposing a `target_system` on `connect()` is probably not what we want. Exposing `source_system` might be, though.

This does a bit of an overhaul over the MAVLink object in the backend to make sure we get this right. The `target_system` is loaded from the first heartbeat we get and fixed after that point. We also have some backend classes which we might expose eventually, but for now demonstrate the use of multiple target systems in one program. e.g.

```
dronekit-sitl copter
```

In one window,

```py
import time
from dronekit import connect
from dronekit.mavlink import MAVConnection

v = connect('tcp:127.0.0.1:5760', wait_ready=True, source_system=255)

o = MAVConnection('udpout:127.0.0.1:14550', source_system=254)
v._handler.pipe(o)
o.start()

while True:
	time.sleep(1)
```

in the next, and 

```
mavproxy.py --master 0.0.0.0:14550 --source-system=254
```

Works to daisy chain a connection _through_ DroneKit. This is obviously using undocumented features (MAVConnection directly) but demonstrates the logic should work if we expose it publicly later.