### PR TITLE
Add links to legacy docs and examples

### DIFF
--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -10,6 +10,11 @@ now need to specify the vehicle target address inside the script.
 
 The sections below outline the main migration areas.
 
+.. note::
+
+    *DroneKit-Python version 1.5* has now been superseded (see these links for legacy `documentation <http://python.dronekit.io/1.5.0/>`_ 
+    and `examples <https://github.com/dronekit/dronekit-python/tree/81bbd80076fb212c9305751333d9924e6b762434/examples>`_).
+
 
 Installation
 ============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,13 +7,16 @@
 Welcome to DroneKit-Python's documentation!
 ===========================================
 
-DroneKit-Python helps you create powerful apps for UAVs. These apps run on a UAV's :ref:`Companion Computer <supported-companion-computers>`, and augment the autopilot by performing tasks that are both computationally intensive and require a low-latency link (e.g. computer vision). 
+DroneKit-Python 2.x helps you create powerful apps for UAVs. These apps run on a UAV's :ref:`Companion Computer <supported-companion-computers>`, and augment the autopilot by performing tasks that are both computationally intensive and require a low-latency link (e.g. computer vision). 
 
 This documentation provides everything you need to :doc:`get started <guide/getting_started>` with DroneKit-Python, including an :doc:`overview <about/overview>` of the API, guide material, a number of demos and examples, and :doc:`API Reference <automodule>`. 
 
 .. tip::
 
-    If you're migrating from DroneKit-Python version 1, check out our comprehensive :ref:`Migration Guide <migrating_dkpy2_0>`.
+    *DroneKit-Python version 1.5* has now been superseded (see these links for legacy `documentation <http://python.dronekit.io/1.5.0/>`_ 
+    and `examples <https://github.com/dronekit/dronekit-python/tree/81bbd80076fb212c9305751333d9924e6b762434/examples>`_).
+    
+    If you're migrating from *DroneKit-Python version 1.x*, check out our comprehensive :ref:`Migration Guide <migrating_dkpy2_0>`.
 
     
 Contents:


### PR DESCRIPTION
Links/text added on front page and migration guide.

@tcr3dr This is good to merge (assuming you OK with it)