### PR TITLE
Versions and capability

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -299,7 +299,7 @@ class Version(object):
             prefix += "Rover-"
 
         release_type="-dev"
-        if(release != None):
+        if(self.release != None):
             if(self.release == 255):
                 release_type = ""
             if(self.release > 192-1):
@@ -1953,6 +1953,10 @@ class Vehicle(HasObservers):
         if rate != None:
             self._master.mav.request_data_stream_send(0, 0, mavutil.mavlink.MAV_DATA_STREAM_ALL,
                                                       rate, 1)
+
+        #Request an AUTOPILOT_VERSION packet
+        capability_msg = self.message_factory.command_long_encode(0, 0, mavutil.mavlink.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, 0, 1, 0, 0, 0, 0, 0, 0)
+        self.send_mavlink(capability_msg)
 
         # Ensure initial parameter download has started.
         while True:

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -257,15 +257,24 @@ class Version(object):
     Version numbers.
 
     An object of this type is returned by :py:attr:`Vehicle.version`
-
     The version number can be read in a few different formats. To get it in a human-readable
     format, just print `vehicle.version`.  This might print somthing like "APM:Copter-3.3.2-rc4".
 
-    Or read the version in its four parts: major, minor, patch, release_type, by calling 
-    `vehicle.version.major`, `vehicle.version.minor`, `vehicle.version.patch` and `vehicle.version.release_type`.
-    Release_type is of the enum `FIRMWARE_VERSION_TYPE` which can be found in `mavutil.mavlink.FIRMWARE_VERSION_TYPE`
+    .. py:attribute:: major
 
-    To check if the version is a stable release, check `vehicle.version.number.is_stable()`
+    Major version number (integer).
+
+    .. py:attribute::minor
+
+    Minor version number (integer).
+
+    .. py:attribute:: patch
+
+    Patch version number (integer).
+
+    .. py:attribute:: release
+
+    Release type (integer). See the enum `FIRMWARE_VERSION_TYPE <http://mavlink.org/messages/common#MAV_AUTOPILOT_GENERIC>`_.
     """
     def __init__(self, raw_version, autopilot_type, vehicle_type):
         self.autopilot_type = autopilot_type
@@ -275,7 +284,7 @@ class Version(object):
             self.major = None
             self.minor = None
             self.patch = None
-            self.stable = None
+            self.release = None
         else:
             self.major   = raw_version >> 24 & 0xFF
             self.minor   = raw_version >> 16 & 0xFF
@@ -283,6 +292,10 @@ class Version(object):
             self.release = raw_version & 0xFF
 
     def is_stable(self):
+        """
+        Returns True if the autopilot reports that the current firmware is a stable
+        release, not a pre-release or development version.
+        """
         return self.release == 255
 
     def __str__(self):
@@ -314,13 +327,57 @@ class Capabilities:
     """
     The capabilities tells us what messages the autopilot is capable of interpreting.
 
-    To check if the autopilot support terrain handling, check if
-    `version.capabilities.terrain_handling is True`.
+    .. py:attribute:: mission_float
 
-    The other possible capabilities to check are `mission_float`, `param_float`,
-    `mission_int`, `command_int`, `param_union`, `fix_type`, ftp`, `set_attitude_target`,
-    `set_attitude_target_local_ned`, `set_altitude_target_global_int`, `actuator_target`,
-    `flight_termination`, `compass_calibration`.
+    Autopilot supports MISSION float message type. (Boolean)
+
+    .. py:attribute:: param_float
+
+    Autopilot supports the new param float message type. (Boolean)
+
+    .. py:attribute:: mission_int
+
+    Autopilot supports MISSION_INT scaled integer message type. (Boolean)
+
+    .. py:attribute:: command_int
+
+    Autopilot supports COMMAND_INT scaled integer message type. (Boolean)
+
+    .. py:attribute:: param_union 
+
+    Autopilot supports the new param union message type. (Boolean)
+
+    .. py:attribute:: ftp
+
+    Autopilot supports ftp for file transfers. (Boolean)
+
+    .. py:attribute:: set_attitude_target
+
+    Autopilot supports commanding attitude offboard. (Boolean)
+
+    .. py:attribute:: set_attitude_target_local_ned
+
+    Autopilot supports commanding position and velocity targets in local NED frame. (Boolean)
+
+    .. py:attribute:: set_attitude_target_global_int
+
+    Autopilot supports commanding position and velocity targets in global scaled integers. (Boolean)
+    
+    .. py:attribute:: terrain
+
+    Autopilot supports terrain protocol / data handling. (Boolean)
+
+    .. py:attribute:: set_actuator_target
+
+    Autopilot supports direct actuator control. (Boolean)
+
+    .. py:attribute:: flight_termination
+
+    Autopilot supports the flight termination command. (Boolean)
+
+    .. py:attribute:: compass_calibration
+
+    Autopilot supports onboard compass calibration. (Boolean)
     """
     def __init__(self, capabilities):
         self.mission_float                  = (((capabilities >> 0)  & 1) == 1)
@@ -333,7 +390,7 @@ class Capabilities:
         self.set_attitude_target_local_ned  = (((capabilities >> 7)  & 1) == 1)
         self.set_altitude_target_global_int = (((capabilities >> 8)  & 1) == 1)
         self.terrain                        = (((capabilities >> 9)  & 1) == 1)
-        self.actuator_target                = (((capabilities >> 10) & 1) == 1)
+        self.set_actuator_target            = (((capabilities >> 10) & 1) == 1)
         self.flight_termination             = (((capabilities >> 11) & 1) == 1)
         self.compass_calibration            = (((capabilities >> 12) & 1) == 1)
 
@@ -1489,14 +1546,14 @@ class Vehicle(HasObservers):
     @property
     def version(self):
         """
-        The autopilot version in a (:py:class:`Version object`).
+        The autopilot version in a :py:class:`Version object`.
         """
         return Version(self._raw_version, self._autopilot_type, self._vehicle_type)
 
     @property
     def capabilities(self):
         """
-        The capabilities of the autopilot in a (:py:class:`Capabilities`) object.
+        The capabilities of the autopilot in a :py:class:`Capabilities` object.
         """
         return Capabilities(self._capabilities)
 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -252,6 +252,73 @@ class Rangefinder(object):
     def __str__(self):
         return "Rangefinder: distance={}, voltage={}".format(self.distance, self.voltage)
 
+class Version(object):
+    """
+    The version number in a few different formats. To get it in a human-readable
+    format, just print `vehicle.version.number`. Or read the version in its four
+    parts: major, minor, patch, release_type, by calling `vehicle.version.number.major`, etc.
+
+    To check if the version is a stable release, check `vehicle.version.number.is_stable()`
+    """
+    def __init__(self, raw_version, autopilot_type, vehicle_type):
+        self.autopilot_type = autopilot_type
+        self.vehicle_type = vehicle_type
+        self.raw_version = raw_version
+        self.major   = raw_version >> 24 & 0xFF
+        self.minor   = raw_version >> 16 & 0xFF
+        self.patch   = raw_version >> 8  & 0xFF
+        self.release = raw_version & 0xFF
+
+    def is_stable(self):
+        return self.release == 255
+
+    def __str__(self):
+        prefix=""
+        if(self.autopilot_type == mavutil.mavlink.MAV_AUTOPILOT_ARDUPILOTMEGA):
+            prefix += "APM:"
+        elif(self.autopilot_type == mavutil.mavlink.MAV_AUTOPILOT_PX4):
+            prefix += "PX4"
+        if(self.vehicle_type == mavutil.mavlink.MAV_TYPE_QUADROTOR):
+            prefix += "Copter"
+        elif(self.vehicle_type == mavutil.mavlink.MAV_TYPE_FIXED_WING):
+            prefix += "Plane"
+        elif(self.vehicle_type == mavutil.mavlink.MAV_TYPE_ROVER):
+            prefix += "Rover"
+
+        release_type="-dev"
+        if(self.release == 255):
+            release_type = ""
+        if(self.release > 192-1):
+            release_type = "-rc" + str(self.release-(192-1))
+        if(self.release > 128-1):
+            release_type = "-beta" + str(self.release-(192-1))
+        if(self.release > 64-1):
+            release_type = "-alpha" + str(self.release-(192-1))
+        return prefix + "-%s.%s.%s" % (self.major, self.minor, self.patch) + release_type
+
+class Capabilities:
+    """
+    The capabilities tells us what messages the autopilot is capable of interpreting.
+    For example, to check if the autopilot supports parachutes, check if `version.capabilities.parachute is True`.
+    Note: This doesn't necessarily mean that a parachute is connected and configured. It only means that the
+    autopilot knows what a parachute is.
+    """
+    def __init__(self, capabilities):
+        self.mission_float                  = (((capabilities >> 0)  & 1) == 1)
+        self.param_float                    = (((capabilities >> 1)  & 1) == 1)
+        self.mission_int                    = (((capabilities >> 2)  & 1) == 1)
+        self.command_int                    = (((capabilities >> 3)  & 1) == 1)
+        self.param_union                    = (((capabilities >> 4)  & 1) == 1)
+        self.fix_type                       = (((capabilities >> 5)  & 1) == 1)
+        self.set_attitude_target            = (((capabilities >> 6)  & 1) == 1)
+        self.set_attitude_target_local_ned  = (((capabilities >> 7)  & 1) == 1)
+        self.set_altitude_target_global_int = (((capabilities >> 8)  & 1) == 1)
+        self.terrain                        = (((capabilities >> 9)  & 1) == 1)
+        self.actuator_target                = (((capabilities >> 10) & 1) == 1)
+        self.flight_termination             = (((capabilities >> 11) & 1) == 1)
+        self.compass_calibration            = (((capabilities >> 12) & 1) == 1)
+        self.parachute                      = (((capabilities >> 13) & 1) == 1)
+
 
 class VehicleMode(object):
     """
@@ -887,6 +954,14 @@ class Vehicle(HasObservers):
             self._mount_yaw = m.pointing_c / 100
             self.notify_attribute_listeners('mount', self.mount_status)
 
+        self._capabilities = 0
+        self._raw_version = 0
+
+        @self.on_message('AUTOPILOT_VERSION')
+        def listener(vehicle, name, m):
+            self._capabilities = m.capabilities
+            self._raw_version = m.flight_sw_version
+
         # gimbal
         self._gimbal = Gimbal(self)
 
@@ -958,6 +1033,8 @@ class Vehicle(HasObservers):
         self._flightmode = 'AUTO'
         self._armed = False
         self._system_status = None
+        self._autopilot_type = 0#PX4, ArduPilot, etc.
+        self._vehicle_type = 0#quadcopter, plane, etc.
 
         @self.on_message('HEARTBEAT')
         def listener(self, name, m):
@@ -967,6 +1044,8 @@ class Vehicle(HasObservers):
             self.notify_attribute_listeners('mode', self.mode, cache=True)
             self._system_status = m.system_status
             self.notify_attribute_listeners('system_status', self.system_status, cache=True)
+            self._autopilot_type = m.autopilot
+            self._vehicle_type = m.type
 
         # Waypoints.
 
@@ -1388,6 +1467,20 @@ class Vehicle(HasObservers):
         Current velocity as a three element list ``[ vx, vy, vz ]`` (in meter/sec).
         """
         return [self._vx, self._vy, self._vz]
+
+    @property
+    def version(self):
+        """
+        The autopilot version in a Version object.
+        """
+        return Version(self._raw_version, self._autopilot_type, self._vehicle_type)
+
+    @property
+    def capabilities(self):
+        """
+        The capabilities of the autopilot in a Capabilities object.
+        """
+        return Capabilities(self._capabilities)
 
     @property
     def attitude(self):

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -47,8 +47,6 @@ import math
 import copy
 import collections
 from pymavlink.dialects.v10 import ardupilotmega
-from pymavlink import mavutil, mavwp
-from dronekit.util import errprinter
 
 
 class APIException(Exception):

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -262,19 +262,19 @@ class Version(object):
 
     .. py:attribute:: major
 
-    Major version number (integer).
+        Major version number (integer).
 
     .. py:attribute::minor
 
-    Minor version number (integer).
+        Minor version number (integer).
 
     .. py:attribute:: patch
 
-    Patch version number (integer).
+        Patch version number (integer).
 
     .. py:attribute:: release
 
-    Release type (integer). See the enum `FIRMWARE_VERSION_TYPE <http://mavlink.org/messages/common#MAV_AUTOPILOT_GENERIC>`_.
+        Release type (integer). See the enum `FIRMWARE_VERSION_TYPE <http://mavlink.org/messages/common#MAV_AUTOPILOT_GENERIC>`_.
     """
     def __init__(self, raw_version, autopilot_type, vehicle_type):
         self.autopilot_type = autopilot_type
@@ -329,55 +329,55 @@ class Capabilities:
 
     .. py:attribute:: mission_float
 
-    Autopilot supports MISSION float message type. (Boolean)
+        Autopilot supports MISSION float message type (Boolean).
 
     .. py:attribute:: param_float
 
-    Autopilot supports the new param float message type. (Boolean)
+        Autopilot supports the new param float message type (Boolean).
 
     .. py:attribute:: mission_int
 
-    Autopilot supports MISSION_INT scaled integer message type. (Boolean)
+        Autopilot supports MISSION_INT scaled integer message type (Boolean).
 
     .. py:attribute:: command_int
 
-    Autopilot supports COMMAND_INT scaled integer message type. (Boolean)
+        Autopilot supports COMMAND_INT scaled integer message type (Boolean).
 
     .. py:attribute:: param_union 
 
-    Autopilot supports the new param union message type. (Boolean)
+        Autopilot supports the new param union message type (Boolean).
 
     .. py:attribute:: ftp
 
-    Autopilot supports ftp for file transfers. (Boolean)
+        Autopilot supports ftp for file transfers (Boolean).
 
     .. py:attribute:: set_attitude_target
 
-    Autopilot supports commanding attitude offboard. (Boolean)
+        Autopilot supports commanding attitude offboard (Boolean).
 
     .. py:attribute:: set_attitude_target_local_ned
 
-    Autopilot supports commanding position and velocity targets in local NED frame. (Boolean)
+        Autopilot supports commanding position and velocity targets in local NED frame (Boolean).
 
     .. py:attribute:: set_attitude_target_global_int
 
-    Autopilot supports commanding position and velocity targets in global scaled integers. (Boolean)
+        Autopilot supports commanding position and velocity targets in global scaled integers (Boolean).
     
     .. py:attribute:: terrain
 
-    Autopilot supports terrain protocol / data handling. (Boolean)
+        Autopilot supports terrain protocol / data handling (Boolean).
 
     .. py:attribute:: set_actuator_target
 
-    Autopilot supports direct actuator control. (Boolean)
+        Autopilot supports direct actuator control (Boolean).
 
     .. py:attribute:: flight_termination
 
-    Autopilot supports the flight termination command. (Boolean)
+        Autopilot supports the flight termination command (Boolean).
 
     .. py:attribute:: compass_calibration
 
-    Autopilot supports onboard compass calibration. (Boolean)
+        Autopilot supports onboard compass calibration (Boolean).
     """
     def __init__(self, capabilities):
         self.mission_float                  = (((capabilities >> 0)  & 1) == 1)

--- a/dronekit/test/sitl/test_capability_and_version.py
+++ b/dronekit/test/sitl/test_capability_and_version.py
@@ -1,0 +1,14 @@
+import time
+
+from dronekit import VehicleMode, connect
+from dronekit.test import with_sitl
+from nose.tools import assert_false, assert_true
+
+
+@with_sitl
+def test_115(connpath):
+    v = connect(connpath, wait_ready=True)
+    time.sleep(5)
+    assert_false(v.capabilities.ftp)
+    assert_true(v.capabilities.mission_float)
+    assert_true(v.version.major is not None)

--- a/dronekit/test/sitl/test_capability_and_version.py
+++ b/dronekit/test/sitl/test_capability_and_version.py
@@ -6,9 +6,11 @@ from nose.tools import assert_false, assert_true
 
 
 @with_sitl
-def test_115(connpath):
+def test_capability_and_version(connpath):
     v = connect(connpath, wait_ready=True)
     time.sleep(5)
     assert_false(v.capabilities.ftp)
-    assert_true(v.capabilities.mission_float)
     assert_true(v.version.major is not None)
+
+    #This will fail because of a problem in Copter3.3. TODO uncomment this line once dronekit sitl uses 3.4
+    #assert_true(v.capabilities.mission_float)

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -25,6 +25,7 @@ vehicle = connect(args.connect, wait_ready=True)
 
 # Get all vehicle attributes (state)
 print "\nGet all vehicle attribute values:"
+print " Autopilot Firmware version: %s" % vehicle.version
 print " Global Location: %s" % vehicle.location.global_frame
 print " Global Location (relative altitude): %s" % vehicle.location.global_relative_frame
 print " Local Location: %s" % vehicle.location.local_frame


### PR DESCRIPTION
This creates two new classes called `version` and `capability`.  The information in these classes is parsed from the `AUTOPILOT_VERSION` message that is sent by the autopilot.  Unfortunately, ardupilot does not send this message automatically, it only sends it after it is requested.  The proper way to request it is with a do-command, like this:

```
#Request an AUTOPILOT_VERSION packet
capability_msg = self.message_factory.command_long_encode(0, 0, mavutil.mavlink.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, 0, 1, 0, 0, 0, 0, 0, 0)
self.send_mavlink(capability_msg)
```

I tried putting this into the vehicle.init() method, but it didn't work for some reason.  @tcr3dr do you know where is the best place to put this?