### PR TITLE
Add easy_install to docs as alternative to apt-get for installing pip

### DIFF
--- a/docs/develop/installation.rst
+++ b/docs/develop/installation.rst
@@ -28,6 +28,12 @@ It is installed from **pip** on all platforms:
 
       sudo apt-get install python-pip python-dev
       
+  Alternatively, the *easy_install* tool provides another way to install pip:
+  
+  .. code-block:: bash
+
+      sudo easy_install pip
+      
 * :doc:`companion-computers` are likely to run on stripped down versions of Linux. Ensure
   you use a variant that supports Python 2.7 and can install Python packages from the Internet.
 * Windows does not come with Python by default, but there are 


### PR DESCRIPTION
This adds an alternative method of installing pip, prior to installing dronekit.

The [original suggestion](https://gitter.im/dronekit/dronekit-python?at=56ac5b976c947b2d74ba54f0) was to replace apt-get with easy_install, but from my reading it looks like this has its own potential issues and might not be as familiar for some users. Instead I have left the quick start alone, but I have outlined both approaches in the more detailed installation instructions.

This should highlight the alternative if developers have problem with the "more modern" method.