### PR TITLE
Update contribution process docs

### DIFF
--- a/docs/contributing/contributions_api.rst
+++ b/docs/contributing/contributions_api.rst
@@ -15,12 +15,12 @@ This article provides a high level overview of how to contribute changes to the 
 Submitting changes
 ==================
 
-Contributors should fork the main `dronekit/dronekit-python/ <https://github.com/dronekit/dronekit-python>`_ 
-repository and contribute changes back to the project master branch using pull requests
+Contributors should create branches on the `dronekit/dronekit-python/ <https://github.com/dronekit/dronekit-python>`_ 
+repository and submit changes back to the master branch using pull requests.
 
 * Changes should be :ref:`tested locally <contributing-test-code>` before submission.
 * Changes to the public API should be :ref:`documented <contributing-to-documentation>` (we will provide subediting support!)
-* Pull requests should be as small and focussed as possible to make them easier to review.
+* Pull requests should be as small and focused as possible to make them easier to review.
 * Pull requests should be rebased against the main project before submission to make integration easier.
 
 

--- a/docs/contributing/contributions_documentation.rst
+++ b/docs/contributing/contributions_documentation.rst
@@ -22,8 +22,8 @@ Submitting changes
 The process and requirements for submitting changes to the documentation are **the same** as when 
 :ref:`contributing to the source code <contributing_api>`. 
 
-As when submitting source code you should fork the main project Github repository and 
-contribute changes back to the project using pull requests. The changes should be tested
+As when submitting source code you create a branch on the main project Github repository and 
+submit your changes using pull requests. The changes should be tested
 locally (by :ref:`building the docs <contributing_building_docs>`) before being submitted.
 
 See :ref:`contributing_api` for more information. 


### PR DESCRIPTION
Now specifies our real contribution approach - branch-off-main-repo, rather than suggesting people fork repo.