### PR TITLE
Make drone delivery example use DK-SITL simulator

### DIFF
--- a/docs/examples/drone_delivery.rst
+++ b/docs/examples/drone_delivery.rst
@@ -80,8 +80,8 @@ In summary, after cloning the repository:
    .. code-block:: bash
 
        python drone_delivery.py --connect udpin:0.0.0.0:14550
-       
- 
+
+
 #. After a short while you should be able to reach your new webserver at http://localhost:8080.  
    Navigate to the **Command** screen, select a target on the map, then select **Go**. 
    The command prompt will show something like the message below. 
@@ -92,7 +92,7 @@ In summary, after cloning the repository:
     
    The web server will switch you to the **Track** screen. You can view the vehicle progress by pressing the 
    **Update** button.
-    
+
 
 Screenshots
 ===========

--- a/docs/examples/drone_delivery.rst
+++ b/docs/examples/drone_delivery.rst
@@ -6,11 +6,6 @@ This example shows how to create a `CherryPy <http://www.cherrypy.org>`_ based w
 displays a mapbox map to let you view the current vehicle position and send the vehicle commands 
 to fly to a particular latitude and longitude.
 
-.. warning::
-
-    At time of writing, this example does not work properly (the vehicle does not take off).
-    For more information see `#357 Mode not changed when message sent inside drone delivery example <https://github.com/dronekit/dronekit-python/issues/357>`_
-
 New functionality demonstrated by this example includes:
 
 * Using attribute observers to be notified of vehicle state changes.
@@ -23,11 +18,6 @@ Running the example
 The example can be run much as described in :doc:`running_examples` (which in turn assumes that the vehicle
 and DroneKit have been set up as described in :ref:`installing_dronekit`). The main exception is that you need to 
 install the CherryPy dependencies and view the behaviour in a web browser.
-    
-If you're using a simulated vehicle remember to :ref:`disable arming checks <disable-arming-checks>` so 
-that the example can run. You can also `add a virtual rangefinder <http://dev.ardupilot.com/wiki/simulation-2/sitl-simulator-software-in-the-loop/using-sitl-for-ardupilot-testing/#adding_a_virtual_rangefinder>`_
-(otherwise the :py:attr:`Vehicle.rangefinder <dronekit.Vehicle.rangefinder>` attribute may return values of ``None`` for the distance
-and voltage). 
 
 In summary, after cloning the repository:
 
@@ -44,42 +34,64 @@ In summary, after cloning the repository:
 
        pip install -r requirements.pip
        
-       
-#. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:
+#. You can run the example against the simulator by specifying the Python script without any arguments.
+   The example will download and start DroneKit-SITL, and then connect to it:
 
    .. code-block:: bash
 
-       python drone_delivery.py --connect 127.0.0.1:14550
-
-   .. note::
-   
-       The ``--connect`` parameter above connects to SITL on udp port 127.0.0.1:14550.
-       This is the default value for the parameter, and may be omitted. 
+       python drone_delivery.py
 
    On the command prompt you should see (something like):
 
-   .. code-block:: bash
+   .. code:: bash
 
-       Connecting to vehicle on: 127.0.0.1:14550
+       >python drone_delivery.py
+       
+       D:\Github\dronekit-python\examples\drone_delivery>drone_delivery.py
+       Starting copter simulator (SITL)
+       SITL already Downloaded.
+       local path: D:\Github\dronekit-python\examples\drone_delivery
+       Connecting to vehicle on: tcp:127.0.0.1:5760
+       >>> APM:Copter V3.3 (d6053245)
        >>> Frame: QUAD
+       >>> Calibrating barometer
+       >>> Initialising APM...
+       >>> barometer calibration complete
+       >>> GROUND START
+       Launching Drone...
        [DEBUG]: Connected to vehicle.
        [DEBUG]: DroneDelivery Start
+       [DEBUG]: Waiting for location...
        [DEBUG]: Waiting for ability to arm...
        [DEBUG]: Running initial boot sequence
        [DEBUG]: Changing to mode: GUIDED
+       [DEBUG]:   ... polled mode: GUIDED
        [DEBUG]: Waiting for arming...
+       >>> ARMING MOTORS
+       >>> GROUND START
+       >>> Initialising APM...
        [DEBUG]: Taking off
        http://localhost:8080/
-    
+       Waiting for cherrypy engine...
+
+#. You can run the example against a specific connection (simulated or otherwise) by passing the :ref:`connection string <get_started_connect_string>` for your vehicle in the ``--connect`` parameter. 
+   For example, to connect to Solo:
+
+   .. code-block:: bash
+
+       python drone_delivery.py --connect udpin:0.0.0.0:14550
+       
+ 
 #. After a short while you should be able to reach your new webserver at http://localhost:8080.  
-   The command prompt will show something like  
+   Navigate to the **Command** screen, select a target on the map, then select **Go**. 
+   The command prompt will show something like the message below. 
     
    .. code-block:: bash
 
        [DEBUG]: Goto: [u'-35.4', u'149.2'], 29.98
     
-   On the web server you can use the **Command** button to set a target location and 
-   the **Track** button to view the moving vehicle (see the screenshots below).
+   The web server will switch you to the **Track** screen. You can view the vehicle progress by pressing the 
+   **Update** button.
     
 
 Screenshots
@@ -133,6 +145,14 @@ We start running a web server by calling ``cherrypy.engine.start()``.
 *CherryPy* is a very small and simple webserver.  It is probably best to refer to their eight line `tutorial <http://www.cherrypy.org/>`_ for more information.
 
 
+
+Known issues
+============
+
+This example has the following issues:
+
+* `#537: Dronekit delivery tracking needs to zoom and also ideally auto update <https://github.com/dronekit/dronekit-python/issues/537>`_ 
+* `#538: Dronekit delivery example does not exit <https://github.com/dronekit/dronekit-python/issues/538>`_
 
 Source code
 ===========


### PR DESCRIPTION
Example now automatically uses DK-SITL if no connection string is specified. I am doing this for all examples (slowly). I also updated the docs (which were incorrect in several place anyway).