### PR TITLE
UPdate running examples page and simulation instructions

### DIFF
--- a/docs/develop/sitl_setup.rst
+++ b/docs/develop/sitl_setup.rst
@@ -8,7 +8,7 @@ The `SITL (Software In The Loop) <http://dev.ardupilot.com/wiki/simulation-2/sit
 simulator allows you to create and test DroneKit-Python apps without a real vehicle (and from the comfort of 
 your own developer desktop!).
 
-SITL can run natively on Linux, Mac and Windows, or within a virtual machine. It can be 
+SITL can run natively on Linux (x86 architecture only), Mac and Windows, or within a virtual machine. It can be 
 installed on the same computer as DroneKit, or on another computer on the same network.
 
 The sections below explain how to install and run SITL, and how to connect to DroneKit-Python and Ground
@@ -20,7 +20,7 @@ Stations at the same time.
 DroneKit-SITL
 =============
 
-DroneKit-SITL is the simplest, fastest and easiest way to run SITL on Windows, Linux, or MAC OSX.
+DroneKit-SITL is the simplest, fastest and easiest way to run SITL on Windows, Linux (x86 architecture only), or Mac OS X.
 It is installed from Python's *pip* tool on all platforms, and works by downloading and running pre-built 
 vehicle binaries that are appropriate for the host operating system.
 
@@ -29,8 +29,12 @@ the `project on Github <https://github.com/dronekit/dronekit-sitl>`_.
 
 .. note:: 
 
-    DroneKit-SITL is still relatively experimental. There are only a few pre-built vehicles and
-    they have not been as well tested as the native builds.  
+    DroneKit-SITL is still relatively experimental and there are only a few pre-built vehicles.
+    
+    The binaries are built and tested on Windows 10, Ubuntu Linux, and Mac OS X
+    "El Capitan". Binaries are only available for x86 architectures. ARM builds 
+    (e.g. for RPi) are not supported.
+    
     Please report any issues on `Github here <https://github.com/dronekit/dronekit-sitl/issues>`_.
 
 Installation

--- a/docs/examples/running_examples.rst
+++ b/docs/examples/running_examples.rst
@@ -4,14 +4,20 @@
 Running the Examples
 ====================
 
-General instructions for running the `example source code <https://github.com/dronekit/dronekit-python/tree/master/examples>`_ are given below.
+General instructions for running the `example source code <https://github.com/dronekit/dronekit-python/tree/master/examples>`_ are given below. More explicit instructions are provided within the documentation for each example (and within the examples themselves by passing the ``-h`` (help) command line argument).
 
 .. tip::
 
-    More explicit instructions may be provided within the documentation for each example, and on the command line using the ``-h`` (help) parameter.
+    The examples all launch the :ref:`dronekit-sitl <dronekit_sitl>` simulator and connect to it by default. The ``--connect`` argument is used to instead specify the :ref:`connection string <get_started_connect_string>` for a target vehicle or an externally managed SITL instance.
+    
+To run the examples:
+
+#. :ref:`Install DroneKit-Python <installing_dronekit>` if you have not already done so! Install :ref:`dronekit-sitl <dronekit_sitl>` if you want to test against simulated vehicles.
 
 #. Get the DroneKit-Python example source code onto your local machine. The easiest way to do this 
-   is to clone the **dronekit-python** repository from Github. On the command prompt enter:
+   is to clone the **dronekit-python** repository from Github. 
+   
+   On the command prompt enter:
 
    .. code-block:: bash
 
@@ -22,24 +28,28 @@ General instructions for running the `example source code <https://github.com/dr
 #. Navigate to the example you wish to run (or specify the full path in the next step). The examples are all stored in 
    subdirectories of **dronekit-python\\examples\\**. 
    
-   To run the :ref:`vehicle_state <example-vehicle-state>` example, you would navigate as shown:
+   For example, to run the :ref:`vehicle_state <example-vehicle-state>` example, you would navigate as shown:
 
    .. code-block:: bash
 
        cd dronekit-python\examples\vehicle_state\
 
 
-#. Start the example, passing the :ref:`connection string <get_started_connect_string>` you wish to use in the ``--connect`` parameter:
+#. Start the example as shown:
 
-   .. code-block:: bash
-
-       python vehicle_state.py --connect 127.0.0.1:14550
-
-   .. note::
+   * To connect to a simulator started/managed by the script:
    
-       The examples all use the ``--connect`` parameter to pass the :ref:`connection string <get_started_connect_string>` into the script. 
-       The command above would be used to connect to :ref:`SITL <sitl_setup>` running on the local machine via UDP port 14550.
-          
+     .. code-block:: bash
+
+         python vehicle_state.py
+
+   * To connect to a specific vehicle, pass its :ref:`connection string <get_started_connect_string>` via the ``connect`` argument. 
+     For example, to run the example on Solo you would use the following command:
+   
+     .. code-block:: bash
+
+         python vehicle_state.py --connect udpin:0.0.0.0:14550
+
 
 .. warning:: 
 


### PR DESCRIPTION
This updates running examples page to make it clear how to run dk-sitl in the examples (basically matches up with all the other changes).

It also tidies up the simulation page, which is a bit more complicated because connecting to a GCS is different depending on how you run SITL.