### PR TITLE
Hgw attribute setters as functions

### DIFF
--- a/examples/simple_goto/simple_goto.py
+++ b/examples/simple_goto/simple_goto.py
@@ -10,11 +10,6 @@ from dronekit import connect, VehicleMode, LocationGlobalRelative
 import time
 
 
-
-
-
-
-
 #Set up option parsing to get connection string
 import argparse  
 parser = argparse.ArgumentParser(description='Commands vehicle using vehicle.simple_goto.')

--- a/examples/simple_goto/simple_goto.py
+++ b/examples/simple_goto/simple_goto.py
@@ -10,6 +10,11 @@ from dronekit import connect, VehicleMode, LocationGlobalRelative
 import time
 
 
+
+
+
+
+
 #Set up option parsing to get connection string
 import argparse  
 parser = argparse.ArgumentParser(description='Commands vehicle using vehicle.simple_goto.')
@@ -52,12 +57,9 @@ def arm_and_takeoff(aTargetAltitude):
     print "Arming motors"
     # Copter should arm in GUIDED mode
     vehicle.mode = VehicleMode("GUIDED")
-    vehicle.armed = True    
-
-    # Confirm vehicle armed before attempting to take off
-    while not vehicle.armed:      
-        print " Waiting for arming..."
-        time.sleep(1)
+    
+    # Arm the vehicle
+    vehicle.try_set_armed() #returns when armed
 
     print "Taking off!"
     vehicle.simple_takeoff(aTargetAltitude) # Take off to target altitude
@@ -74,17 +76,20 @@ def arm_and_takeoff(aTargetAltitude):
 
 arm_and_takeoff(10)
 
+
 print "Set default/target airspeed to 3"
-vehicle.airspeed = 3
+vehicle.try_set_target_airspeed(3)
 
 print "Going towards first point for 30 seconds ..."
 point1 = LocationGlobalRelative(-35.361354, 149.165218, 20)
 vehicle.simple_goto(point1)
 
+
 # sleep so we can see the change in map
 time.sleep(30)
 
 print "Going towards second point for 30 seconds (groundspeed set to 10 m/s) ..."
+vehicle.try_set_target_groundspeed(10)
 point2 = LocationGlobalRelative(-35.363244, 149.168801, 20)
 vehicle.simple_goto(point2, groundspeed=10)
 

--- a/examples/simple_goto/simple_goto.py
+++ b/examples/simple_goto/simple_goto.py
@@ -78,7 +78,7 @@ arm_and_takeoff(10)
 
 
 print "Set default/target airspeed to 3"
-vehicle.try_set_target_airspeed(3)
+vehicle.try_set_target_airspeed(3, wait_ready=False)
 
 print "Going towards first point for 30 seconds ..."
 point1 = LocationGlobalRelative(-35.361354, 149.165218, 20)
@@ -88,8 +88,7 @@ vehicle.simple_goto(point1)
 # sleep so we can see the change in map
 time.sleep(30)
 
-print "Going towards second point for 30 seconds (groundspeed set to 10 m/s) ..."
-vehicle.try_set_target_groundspeed(10)
+print "Going towards second point for 30 seconds (groundspeed set to 10 m/s in goto) ..."
 point2 = LocationGlobalRelative(-35.363244, 149.168801, 20)
 vehicle.simple_goto(point2, groundspeed=10)
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -78,10 +78,10 @@ print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
 print " Heading: %s" % vehicle.heading
 print " Is Armable?: %s" % vehicle.is_armable
 print " System status: %s" % vehicle.system_status.state
-print " Groundspeed: %s" % vehicle.groundspeed    # settable
-print " Airspeed: %s" % vehicle.airspeed    # settable
-print " Mode: %s" % vehicle.mode.name    # settable
-print " Armed: %s" % vehicle.armed    # settable
+print " Groundspeed: %s" % vehicle.groundspeed    
+print " Airspeed: %s" % vehicle.airspeed
+print " Mode: %s" % vehicle.mode.name
+print " Armed: %s" % vehicle.armed
 
 
 
@@ -113,11 +113,21 @@ cmds.wait_ready()
 print " New Home Location (from vehicle - altitude should be 222): %s" % vehicle.home_location
 
 
-print "\nSet Vehicle.mode = GUIDED (currently: %s)" % vehicle.mode.name 
-vehicle.mode = VehicleMode("GUIDED")
-while not vehicle.mode.name=='GUIDED':  #Wait until mode has changed
-    print " Waiting for mode change ..."
-    time.sleep(1)
+print "\nSet Vehicle mode to GUIDED (currently: %s)" % vehicle.mode.name 
+vehicle.try_set_mode(VehicleMode("GUIDED"))
+print " New mode: %s" % vehicle.mode.name 
+
+print "\nSet Vehicle mode to STABILIZE (currently: %s)" % vehicle.mode.name 
+vehicle.try_set_mode("STABILIZE")
+print " New mode: %s" % vehicle.mode.name 
+
+print "\nSet Vehicle.mode = GUIDED without waiting  (currently: %s)" % vehicle.mode.name 
+vehicle.try_set_mode(value=VehicleMode("GUIDED"), wait_ready=False)
+while not vehicle.mode.name=="GUIDED":
+    print " Waiting for mode change..."
+    time.sleep(0.3)
+print " New mode: %s" % vehicle.mode.name 
+
 
 
 # Check that vehicle is armable
@@ -126,12 +136,22 @@ while not vehicle.is_armable:
     time.sleep(1)
     # If required, you can provide additional information about initialisation
     # using `vehicle.gps_0.fix_type` and `vehicle.mode.name`.
+
+print "\nSend arm message and wait (currently: %s)" % vehicle.armed
+if vehicle.is_armable: 
+    vehicle.try_set_armed() #returns when armed
+    print " Vehicle is armed: %s" % vehicle.armed 
+
+print "\nSend disarm message and wait (currently: %s)" % vehicle.armed
+vehicle.try_set_armed(value=False) #returns when armed
+print " Vehicle is armed: %s" % vehicle.armed     
     
-print "\nSet Vehicle.armed=True (currently: %s)" % vehicle.armed 
-vehicle.armed = True
+print "\nSend arm message without waiting (currently: %s)" % vehicle.armed
+# This non-waiting form is not recommended.
+vehicle.try_set_armed(wait_ready=False)
 while not vehicle.armed:
     print " Waiting for arming..."
-    time.sleep(1)
+    time.sleep(0.3)
 print " Vehicle is armed: %s" % vehicle.armed 
 
 
@@ -170,8 +190,8 @@ def decorated_mode_callback(self, attr_name, value):
     # `value` is the updated attribute value.
     print " CALLBACK: Mode changed to", value
 
-print " Set mode=STABILIZE (currently: %s) and wait for callback" % vehicle.mode.name 
-vehicle.mode = VehicleMode("STABILIZE")
+print " Set mode=STABILIZE (currently: %s) and wait for callback" % vehicle.mode.name
+vehicle.try_set_mode(VehicleMode("STABILIZE"))
 
 print " Wait 2s so callback invoked before moving to next example"
 time.sleep(2)
@@ -249,8 +269,8 @@ vehicle.parameters['THR_MIN']=30
 
 ## Reset variables to sensible values.
 print "\nReset vehicle attributes/parameters and exit"
-vehicle.mode = VehicleMode("STABILIZE")
-vehicle.armed = False
+vehicle.try_set_mode(value=VehicleMode("STABILIZE"))
+vehicle.try_set_armed(value=False)
 vehicle.parameters['THR_MIN']=130
 vehicle.parameters['THR_MID']=500
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -99,18 +99,11 @@ print "\n Home location: %s" % vehicle.home_location
 # Set vehicle home_location, mode, and armed attributes (the only settable attributes)
 
 print "\nSet new home location"
-# Home location must be within 50km of EKF home location (or setting will fail silently)
-# In this case, just set value to current location with an easily recognisable altitude (222)
+# Set home location to current location but change altitude to 222)
 my_location_alt = vehicle.location.global_frame
 my_location_alt.alt = 222.0
-vehicle.home_location = my_location_alt
-print " New Home Location (from attribute - altitude should be 222): %s" % vehicle.home_location
-
-#Confirm current value on vehicle by re-downloading commands
-cmds = vehicle.commands
-cmds.download()
-cmds.wait_ready()
-print " New Home Location (from vehicle - altitude should be 222): %s" % vehicle.home_location
+vehicle.try_set_home_location(my_location_alt)
+print " New Home Location (altitude should be 222): %s" % vehicle.home_location
 
 
 print "\nSet Vehicle mode to GUIDED (currently: %s)" % vehicle.mode.name 


### PR DESCRIPTION
This adds setter functions for mode, armed, home_location, airspeed and groundspeed attributes and adds documentation to mark the old attributes as deprecated.

The reason for this change is that the attribute setters have unexpected behaviour (for users) - specifically, setting the value of these attributes does not change the value immediately and may or may not work.

By adding appropriately named setter functions we make it clear that the messages may or may not be received and we've added waiting versions that will make best effort to verify the success of the message. 

Overall these methods are safer and easier than the attributes, and reduce the amount of code that  developers need to write. 

The attribute setters will be removed in a future version.
