### PR TITLE
Validate existence of custom_mode before setting

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1162,7 +1162,8 @@ class Vehicle(HasObservers):
             self._armed = (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED) != 0
             self.notify_attribute_listeners('armed', self.armed, cache=True)
             if self._master.mode_mapping() != None:
-                self._flightmode = {v: k for k, v in self._master.mode_mapping().items()}[m.custom_mode]
+                if m.custom_mode in {v: k for k, v in self._master.mode_mapping().items()}:
+                    self._flightmode = {v: k for k, v in self._master.mode_mapping().items()}[m.custom_mode]
             self.notify_attribute_listeners('mode', self.mode, cache=True)
             self._system_status = m.system_status
             self.notify_attribute_listeners('system_status', self.system_status, cache=True)

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1162,8 +1162,9 @@ class Vehicle(HasObservers):
             self._armed = (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED) != 0
             self.notify_attribute_listeners('armed', self.armed, cache=True)
             if self._master.mode_mapping() != None:
-                if m.custom_mode in {v: k for k, v in self._master.mode_mapping().items()}:
-                    self._flightmode = {v: k for k, v in self._master.mode_mapping().items()}[m.custom_mode]
+                flightmodesById = {v: k for k, v in self._master.mode_mapping().items()}
+                if m.custom_mode in flightmodesById:
+                    self._flightmode = flightmodesById[m.custom_mode]
             self.notify_attribute_listeners('mode', self.mode, cache=True)
             self._system_status = m.system_status
             self.notify_attribute_listeners('system_status', self.system_status, cache=True)


### PR DESCRIPTION
This fixes exceptions when the autopilot identifies with an unknown custom_mode
This is required at least until PX4 custom modes have been added to pymavlink