### PR TITLE
Splits outbound messages into its own thread.

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2705,7 +2705,8 @@ def connect(ip,
             rate=4,
             baud=115200,
             heartbeat_timeout=30,
-            source_system=255):
+            source_system=255,
+            use_native=False):
     """
     Returns a :py:class:`Vehicle` object connected to the address specified by string parameter ``ip``. 
     Connection string parameters (``ip``) for different targets are listed in the :ref:`getting started guide <get_started_connecting>`.
@@ -2741,6 +2742,7 @@ def connect(ip,
     :param int heartbeat_timeout: Connection timeout value in seconds (default is 30s). 
         If a heartbeat is not detected within this time an exception will be raised.    
     :param int source_system: The MAVLink ID of the :py:class:`Vehicle` object returned by this method (by default 255).
+    :param bool use_native: Use precompiled MAVLink parser.
 
         .. note::
 
@@ -2759,7 +2761,7 @@ def connect(ip,
     if not vehicle_class:
         vehicle_class = Vehicle
 
-    handler = MAVConnection(ip, baud=baud, source_system=source_system)
+    handler = MAVConnection(ip, baud=baud, source_system=source_system, use_native=use_native)
     vehicle = vehicle_class(handler)
     
     if status_printer:

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2605,7 +2605,11 @@ class CommandSequence(object):
 
         # Add home point again.
         self.wait_ready()
-        home = self._vehicle._wploader.wp(0)
+        home = None
+        try:
+            home = self._vehicle._wploader.wp(0)
+        except:
+            pass
         self._vehicle._wploader.clear()
         if home:
             self._vehicle._wploader.add(home, comment='Added by DroneKit')

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1452,9 +1452,10 @@ class Vehicle(HasObservers):
         """
         name = str(name)
         if name in self._message_listeners:
-            self._message_listeners[name].remove(fn)
-            if len(self._message_listeners[name]) == 0:
-                del self._message_listeners[name]
+            if fn in self._message_listeners[name]:
+                self._message_listeners[name].remove(fn)
+                if len(self._message_listeners[name]) == 0:
+                    del self._message_listeners[name]
 
     def notify_message_listeners(self, name, msg):
         for fn in self._message_listeners.get(name, []):

--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -220,13 +220,19 @@ class MAVConnection(object):
         # vehicle -> self -> target
         @self.forward_message
         def callback(_, msg):
-            target.out_queue.put(msg.pack(target.master.mav))
+            try:
+                target.out_queue.put(msg.pack(target.master.mav))
+            except:
+                errprinter('>>> Could not pack this object on receive: %s' % type(msg))
 
         # target -> self -> vehicle
         @target.forward_message
         def callback(_, msg):
             msg = copy.copy(msg)
             target.fix_targets(msg)
-            self.out_queue.put(msg.pack(self.master.mav))
+            try:
+                self.out_queue.put(msg.pack(self.master.mav))
+            except:
+                errprinter('>>> Could not pack this object on forward: %s' % type(msg))
 
         return target

--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -223,7 +223,11 @@ class MAVConnection(object):
             try:
                 target.out_queue.put(msg.pack(target.master.mav))
             except:
-                errprinter('>>> Could not pack this object on receive: %s' % type(msg))
+                try:
+                    assert len(msg.get_msgbuf()) > 0
+                    target.out_queue.put(msg.get_msgbuf())
+                except:
+                    errprinter('>>> Could not pack this object on receive: %s' % type(msg))
 
         # target -> self -> vehicle
         @target.forward_message
@@ -233,6 +237,10 @@ class MAVConnection(object):
             try:
                 self.out_queue.put(msg.pack(self.master.mav))
             except:
-                errprinter('>>> Could not pack this object on forward: %s' % type(msg))
+                try:
+                    assert len(msg.get_msgbuf()) > 0
+                    self.out_queue.put(msg.get_msgbuf())
+                except:
+                    errprinter('>>> Could not pack this object on forward: %s' % type(msg))
 
         return target


### PR DESCRIPTION
We maintain a separate thread for outbound messages so that the main thread as well as the reading thread can send messages.

Right now outbound messages are sent in lockstep with reading messages; this actually creates huge problems with high-rate telemetry (on Solo proper). Splitting it into a concurrent thread passes tests but also improves output rate greatly.

Also, we add use_native.