### PR TITLE
Fix ports in example documents

### DIFF
--- a/docs/examples/flight_replay.rst
+++ b/docs/examples/flight_replay.rst
@@ -53,7 +53,7 @@ In summary, after cloning the repository:
         Generated 100 waypoints from tlog
        Starting copter simulator (SITL)
        SITL already Downloaded.
-       Connecting to vehicle on: tcp:127.0.0.1:5
+       Connecting to vehicle on: tcp:127.0.0.1:5760
        >>> APM:Copter V3.3 (d6053245)
        >>> Frame: QUAD
        >>> Calibrating barometer

--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -37,7 +37,7 @@ In summary, after cloning the repository:
 
    .. code:: bash
 
-       Connecting to vehicle on: 170.0.0.1:14550
+       Connecting to vehicle on: tcp:127.0.0.1:5760
        >>> APM:Copter V3.3 (d6053245)
        >>> Frame: QUAD
        >>> Calibrating barometer


### PR DESCRIPTION
Hi there,

Could you update [the example documents](http://python.dronekit.io/examples/vehicle_state.html) since the default port is not `127.0.0.1: 14550` anymore and it's confusing to try the examples?
I also fixed the wrong value in the current docs just in case.