### PR TITLE
Support Python 3 as well as Python 2

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -40,7 +40,8 @@ import platform
 import re
 from dronekit.util import errprinter
 from pymavlink import mavutil, mavwp
-from Queue import Queue, Empty
+try: from Queue import Queue, Empty # Python 2
+except ImportError: from queue import Queue, Empty # Python 3
 from threading import Thread
 import types
 import threading

--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -10,7 +10,8 @@ import dronekit
 from dronekit import APIException
 from dronekit.util import errprinter
 from pymavlink import mavutil, mavwp
-from Queue import Queue, Empty
+try: from Queue import Queue, Empty # Python 2
+except ImportError: from Queue import Queue, Empty # Python 3
 from threading import Thread
 import types
 


### PR DESCRIPTION
This is the very beginnings of support. Hopefully other people can start testing and finding where the issues are.

This is enough to make `import dronekit` work under Py3.
