### PR TITLE
MAV Type for rover was incorrect.

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -341,7 +341,7 @@ class Version(object):
             prefix += "Copter-"
         elif(self.vehicle_type == mavutil.mavlink.MAV_TYPE_FIXED_WING):
             prefix += "Plane-"
-        elif(self.vehicle_type == mavutil.mavlink.MAV_TYPE_ROVER):
+        elif(self.vehicle_type == mavutil.mavlink.MAV_TYPE_GROUND_ROVER):
             prefix += "Rover-"
         else:
             prefix += "UnknownVehicleType%d-" % (self.vehicle_type)


### PR DESCRIPTION
When connecting to AMPRovers this failed due to the incorrect type, This is now corrected