### PR TITLE
#610: Wrap iterable call in try..except to deal with unrecognised vehicle codes

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1521,7 +1521,10 @@ class Vehicle(HasObservers):
         return mavutil.mode_mapping_bynumber(self._vehicle_type)
 
     def _is_mode_available(self, mode_code):
-        return mode_code in self._mode_mapping_bynumber
+        try:
+            return mode_code in self._mode_mapping_bynumber
+        except:
+            return False
 
     #
     # Operations to support the standard API.

--- a/dronekit/test/sitl/test_modeavailable.py
+++ b/dronekit/test/sitl/test_modeavailable.py
@@ -1,0 +1,24 @@
+"""
+This test represents a simple demo for testing.
+Feel free to copy and modify at your leisure.
+"""
+
+import time
+import sys
+import os
+from dronekit import connect, VehicleMode
+from dronekit.test import with_sitl
+from nose.tools import assert_equals
+
+@with_sitl
+def test_timeout(connpath):
+    v = connect(connpath)
+    
+    # Set the vehicle and autopilot type to 'unsupported' types that MissionPlanner uses as of 17.Apr.2016
+    v._vehicle_type = 6
+    v._autopilot_type = 8
+
+    # The above types trigger 'TypeError: argument of type 'NoneType' is not iterable' which is addressed in issue #610
+    is_available = v._is_mode_available(0)
+
+    v.close()

--- a/dronekit/test/sitl/test_modeavailable.py
+++ b/dronekit/test/sitl/test_modeavailable.py
@@ -1,6 +1,5 @@
 """
-This test represents a simple demo for testing.
-Feel free to copy and modify at your leisure.
+Simple test to trigger a bug in Vehicle class: issue #610 fixed in PR #611
 """
 
 import time


### PR DESCRIPTION
Mode code isn't always in the mode mappings - for example mode 0 that GCS seem to use.  Handle the exception and return a false which seems to be logically correct return in this case.