### PR TITLE
enable udpin-multi

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,8 @@ trim_trailing_whitespace = true
 [*.py]
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = LF
 
 [*.mk]
 indent_style = tab


### PR DESCRIPTION
This enables udpin-multi mode, you can now setup dronekit to allow udpin from multiple sources, I have personally tested with up to 4, its not a hard limit its just what i was testing with, didn't really test with more but I'm sure we can support them as long as host has resources.

This feature is particularly special since it allows you to write a poor man's *`telem_forwarder`, this means we can now replicate some of its features in a cross-os environment w/o porting it.

*`telem_forwarder` is a service that lives inside 3DR Solo in between all of its responsibilities it allows you to write back to a `udpin` source from multiple clients and streams back mavlink to you from the port you started writing to.

@peterbarker I think you are going to want to review this since you have experience with `telem_forwarder`, this is specially important to us right now for development, let me know if you can't review.