### PR TITLE
adds notification whenever home location is changed

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1207,6 +1207,7 @@ class Vehicle(HasObservers):
         @self.on_message(['HOME_POSITION'])
         def listener(self, name, msg):
             self._home_location = LocationGlobal(msg.latitude/1.0e7, msg.longitude/1.0e7, msg.altitude/1000.0);
+            self.notify_attribute_listeners('home_location', self.home_location, cache=True)
             
         @self.on_message(['WAYPOINT', 'MISSION_ITEM'])
         def listener(self, name, msg):


### PR DESCRIPTION
Now we're updating the home_location from messages we can reasonably add attribute notification. Obviously this won't work before notification messages were added (we probably should add documentation to state that, rather than just saying "notification not supported".

This fixes minor bug in #646