### PR TITLE
fix a global_frame altitude caused bug in sitl test

### DIFF
--- a/dronekit/test/sitl/test_goto.py
+++ b/dronekit/test/sitl/test_goto.py
@@ -1,7 +1,7 @@
 """
 simple_goto.py: GUIDED mode "simple goto" example (Copter Only)
 
-The example demonstrates how to arm and takeoff in Copter and how to navigate to 
+The example demonstrates how to arm and takeoff in Copter and how to navigate to
 points using Vehicle.simple_goto.
 
 Full documentation is provided at http://python.dronekit.io/examples/simple_goto.html
@@ -60,9 +60,9 @@ def test_goto(connpath):
         # processing the goto (otherwise the command after
         # Vehicle.simple_takeoff will execute immediately).
         while True:
-            # print " Altitude: ", vehicle.location.alt
+            # print " Altitude: ", vehicle.location.global_relative_frame.alt
             # Test for altitude just below target, in case of undershoot.
-            if vehicle.location.global_frame.alt >= aTargetAltitude * 0.95:
+            if vehicle.location.global_relative_frame.alt >= aTargetAltitude * 0.95:
                 # print "Reached target altitude"
                 break
 


### PR DESCRIPTION
fix a bug where global_frame is used in case which global_relative_frame should be used instead, it causes the drone to take off using a very low sea-level altitude, so it won't leave the ground and its engine will be disarmed shortly after.