### PR TITLE
Add flake8 --exit-zero to the Travis CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ python:
 
 install:
   - 'pip install -r requirements.txt'
+  - pip install flake8
+
+before_script:
+  flake8 . --count --exit-zero --max-line-length=120 --statistics
 
 script:
   - 'nosetests --debug=nose,nose.importer --debug-log=nose_debug -svx dronekit.test.unit'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install flake8
 
 before_script:
-  flake8 . --count --exit-zero --max-line-length=120 --statistics
+  flake8 . --count --exit-zero --max-line-length=120 --statistics 
 
 script:
   - 'nosetests --debug=nose,nose.importer --debug-log=nose_debug -svx dronekit.test.unit'


### PR DESCRIPTION
flake8 provides code improvement suggestions to PR submitters.
The --exit-zero flag prevents flake8 from halting the build process.

It currently makes > 1,000 suggestions in the dronekit-python codebase.  Many are incidental but several that are quite useful to fix.