### PR TITLE
log all errprinter data using syslogd

### DIFF
--- a/dronekit/util.py
+++ b/dronekit/util.py
@@ -1,7 +1,19 @@
 from __future__ import print_function
 import sys
+import logging
+import logging.config
 
+class Logger():
+    def __init__(self):
+        logging.config.fileConfig("/etc/shotmanager.conf")
+        self.xlog = logging.getLogger("dkpy")
+
+    def log(self, data):
+        self.xlog.info(str(data).replace("\0", ""))
+
+logger = Logger()
 
 def errprinter(*args):
     print(*args, file=sys.stderr)
+    logger.log(*args)
     sys.stderr.flush()


### PR DESCRIPTION
* expects a configuration file to exist at “/etc/shotmanager.conf”
* expects this file to contain a section called “dkpy”