### PR TITLE
add support for a logger function in errprinter

### DIFF
--- a/dronekit/util.py
+++ b/dronekit/util.py
@@ -3,9 +3,8 @@ import sys
 
 
 def errprinter(*args):
-    print(*args, file=sys.stderr)
-    sys.stderr.flush()
     logger(*args)
 
 def logger(*args):
-    pass
+    print(*args, file=sys.stderr)
+    sys.stderr.flush()

--- a/dronekit/util.py
+++ b/dronekit/util.py
@@ -5,3 +5,7 @@ import sys
 def errprinter(*args):
     print(*args, file=sys.stderr)
     sys.stderr.flush()
+    logger(*args)
+
+def logger(*args):
+    pass


### PR DESCRIPTION
* this enables other software to monkey patch the logger function to capture dronekit output and exceptions

I would also like to backport this change to `2.8.0` and release a `2.8.1` so we can get this feature without having to upgrade to `2.9.0` yet. I'd be glad to push my branch and tag it as a `2.8.1` release once this is merged.