### PR TITLE
fix missing ** operator

### DIFF
--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -140,7 +140,7 @@ class MAVConnection(object):
 
         def newsendfn(mavmsg, **kwargs):
             self.fix_targets(mavmsg)
-            return sendfn(mavmsg, kwargs)
+            return sendfn(mavmsg, **kwargs)
 
         self.master.mav.send = newsendfn
 

--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -138,9 +138,9 @@ class MAVConnection(object):
         # Monkey-patch MAVLink object for fix_targets.
         sendfn = self.master.mav.send
 
-        def newsendfn(mavmsg, **kwargs):
+        def newsendfn(mavmsg, *args, **kwargs):
             self.fix_targets(mavmsg)
-            return sendfn(mavmsg, **kwargs)
+            return sendfn(mavmsg, *args, **kwargs)
 
         self.master.mav.send = newsendfn
 


### PR DESCRIPTION
in project pymavlink, all mavlink dialects define the send method (in their Mavlink class) as:
"def send(self, mavmsg, force_mavlink1=False):
    ...
"

In dronekit-pyhton project in file mavlink.py, there is a monkey patch on the mavlink send method to add extra processing (target fixing). fixed mavmsg is retransmitted back in original mavlink send function, but  unfortunately, all other parameters (kwargs) are transmitted back as dictionary params.

context: 
I found this bug while trying to activate mavlink2 between SITL and my dronekit script: Whatever i tried, sent mavlink messages where always in V1. With this fix i could achieve mavlink 2 communication