### PR TITLE
fix BaseException.message deprecated in 2.6 and now an error in 3.x

### DIFF
--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -182,7 +182,7 @@ class MAVConnection(object):
                         errprinter('>>> mav send error:', e)
                         break
             except APIException as e:
-                errprinter('>>> ' + str(e.message))
+                errprinter('>>> ' + str(e))
                 self._alive = False
                 self.master.close()
                 self._death_error = e
@@ -237,7 +237,7 @@ class MAVConnection(object):
                                 errprinter('>>> ' + str(e))
 
             except APIException as e:
-                errprinter('>>> ' + str(e.message))
+                errprinter('>>> ' + str(e))
                 self._alive = False
                 self.master.close()
                 self._death_error = e


### PR DESCRIPTION
BaseException.message was deprecated in 2.6 and now produces an Exception in 3.x.

Replace str(e.message) with str(e). Result should be the same in almost all cases.

See http://stackoverflow.com/a/19378402/3571110 for comments about potential differences.