### PR TITLE
Update requirements.txt to use pymavlink 2.2.3+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymavlink>=2.0.6
+pymavlink>=2.2.3
 monotonic>=1.3
 future>=0.15.2
 nose==1.3.7


### PR DESCRIPTION
Updates Pymavlink so it works without error on latest PX4.  Tested on 2.2.3 (though apparently 2.2.2 should work)