### PR TITLE
Avoid runtime NameError by defining `time_max` in sitl/test_110.py

### DIFF
--- a/dronekit/test/sitl/test_110.py
+++ b/dronekit/test/sitl/test_110.py
@@ -43,7 +43,8 @@ def test_110(connpath):
     vehicle.armed = True
 
     # Wait for ACK.
-    wait_for(lambda : armed_callback.called, 10)
+    time_max = 10
+    wait_for(lambda : armed_callback.called, time_max)
 
     # Ensure the callback was called.
     assert armed_callback.called > 0, "Callback should have been called within %d seconds" % (time_max,)


### PR DESCRIPTION
Without this change, a NameError is raised on line 50.

https://travis-ci.org/dronekit/dronekit-python/jobs/271892375#L606-L608