### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - SITL_RATE=200
 
 python:
-  - 2.7.13
+  - 2.7
   - 3.6
 
 before_install:
@@ -17,10 +17,10 @@ install:
   - pip install flake8
 
 before_script:
-  # --exit-zero means that flake8 will not stop the build
-  # 127 characters is the width of a GitHub editor
-  - flake8 . --count --exit-zero  --max-line-length=127 --select=E999 --statistics  # syntax errors
-  - flake8 . --count --exit-zero  --max-line-length=127 --statistics
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - nosetests --debug=nose,nose.importer --debug-log=nose_debug -svx dronekit.test.unit
@@ -41,7 +41,6 @@ notifications:
 matrix:
   allow_failures:
   - python: 3.6
-  fast_finish: true
 
 branches:
   only:

--- a/examples/channel_overrides/channel_overrides.py
+++ b/examples/channel_overrides/channel_overrides.py
@@ -17,6 +17,7 @@ and we will try to find a better alternative: https://github.com/dronekit/dronek
 
 Full documentation is provided at http://python.dronekit.io/examples/channel_overrides.html
 """
+from __future__ import print_function
 from dronekit import connect
 
 
@@ -39,61 +40,61 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 # Get all original channel values (before override)
-print "Channel values from RC Tx:", vehicle.channels
+print("Channel values from RC Tx:", vehicle.channels)
 
 # Access channels individually
-print "Read channels individually:"
-print " Ch1: %s" % vehicle.channels['1']
-print " Ch2: %s" % vehicle.channels['2']
-print " Ch3: %s" % vehicle.channels['3']
-print " Ch4: %s" % vehicle.channels['4']
-print " Ch5: %s" % vehicle.channels['5']
-print " Ch6: %s" % vehicle.channels['6']
-print " Ch7: %s" % vehicle.channels['7']
-print " Ch8: %s" % vehicle.channels['8']
-print "Number of channels: %s" % len(vehicle.channels)
+print("Read channels individually:")
+print(" Ch1: %s" % vehicle.channels['1'])
+print(" Ch2: %s" % vehicle.channels['2'])
+print(" Ch3: %s" % vehicle.channels['3'])
+print(" Ch4: %s" % vehicle.channels['4'])
+print(" Ch5: %s" % vehicle.channels['5'])
+print(" Ch6: %s" % vehicle.channels['6'])
+print(" Ch7: %s" % vehicle.channels['7'])
+print(" Ch8: %s" % vehicle.channels['8'])
+print("Number of channels: %s" % len(vehicle.channels))
 
 
 # Override channels
-print "\nChannel overrides: %s" % vehicle.channels.overrides
+print("\nChannel overrides: %s" % vehicle.channels.overrides)
 
-print "Set Ch2 override to 200 (indexing syntax)"
+print("Set Ch2 override to 200 (indexing syntax)")
 vehicle.channels.overrides['2'] = 200
-print " Channel overrides: %s" % vehicle.channels.overrides
-print " Ch2 override: %s" % vehicle.channels.overrides['2']
+print(" Channel overrides: %s" % vehicle.channels.overrides)
+print(" Ch2 override: %s" % vehicle.channels.overrides['2'])
 
-print "Set Ch3 override to 300 (dictionary syntax)"
+print("Set Ch3 override to 300 (dictionary syntax)")
 vehicle.channels.overrides = {'3':300}
-print " Channel overrides: %s" % vehicle.channels.overrides
+print(" Channel overrides: %s" % vehicle.channels.overrides)
 
-print "Set Ch1-Ch8 overrides to 110-810 respectively"
+print("Set Ch1-Ch8 overrides to 110-810 respectively")
 vehicle.channels.overrides = {'1': 110, '2': 210,'3': 310,'4':4100, '5':510,'6':610,'7':710,'8':810}
-print " Channel overrides: %s" % vehicle.channels.overrides 
+print(" Channel overrides: %s" % vehicle.channels.overrides) 
 
 
 # Clear override by setting channels to None
-print "\nCancel Ch2 override (indexing syntax)"
+print("\nCancel Ch2 override (indexing syntax)")
 vehicle.channels.overrides['2'] = None
-print " Channel overrides: %s" % vehicle.channels.overrides 
+print(" Channel overrides: %s" % vehicle.channels.overrides) 
 
-print "Clear Ch3 override (del syntax)"
+print("Clear Ch3 override (del syntax)")
 del vehicle.channels.overrides['3']
-print " Channel overrides: %s" % vehicle.channels.overrides 
+print(" Channel overrides: %s" % vehicle.channels.overrides) 
 
-print "Clear Ch5, Ch6 override and set channel 3 to 500 (dictionary syntax)"
+print("Clear Ch5, Ch6 override and set channel 3 to 500 (dictionary syntax)")
 vehicle.channels.overrides = {'5':None, '6':None,'3':500}
-print " Channel overrides: %s" % vehicle.channels.overrides 
+print(" Channel overrides: %s" % vehicle.channels.overrides) 
 
-print "Clear all overrides"
+print("Clear all overrides")
 vehicle.channels.overrides = {}
-print " Channel overrides: %s" % vehicle.channels.overrides 
+print(" Channel overrides: %s" % vehicle.channels.overrides) 
 
 #Close vehicle object before exiting script
-print "\nClose vehicle object"
+print("\nClose vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/create_attribute/create_attribute.py
+++ b/examples/create_attribute/create_attribute.py
@@ -14,6 +14,7 @@ intercepted using the message_listener decorator.
 
 Full documentation is provided at http://python.dronekit.io/examples/create_attribute.html
 """
+from __future__ import print_function
 
 from dronekit import connect, Vehicle
 from my_vehicle import MyVehicle #Our custom vehicle class
@@ -40,7 +41,7 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True, vehicle_class=MyVehicle)
 
 # Add observer for the custom attribute
@@ -48,17 +49,17 @@ vehicle = connect(connection_string, wait_ready=True, vehicle_class=MyVehicle)
 def raw_imu_callback(self, attr_name, value):
     # attr_name == 'raw_imu'
     # value == vehicle.raw_imu
-    print value
+    print(value)
 
 vehicle.add_attribute_listener('raw_imu', raw_imu_callback)
 
-print 'Display RAW_IMU messages for 5 seconds and then exit.'
+print('Display RAW_IMU messages for 5 seconds and then exit.')
 time.sleep(5)
 
 #The message listener can be unset using ``vehicle.remove_message_listener``
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/flight_replay/flight_replay.py
+++ b/examples/flight_replay/flight_replay.py
@@ -10,6 +10,7 @@ the flight by sending waypoints to a vehicle.
 
 Full documentation is provided at http://python.dronekit.io/examples/flight_replay.html
 """
+from __future__ import print_function
 
 from dronekit import connect, Command, VehicleMode, LocationGlobalRelative
 from pymavlink import mavutil
@@ -107,7 +108,7 @@ def arm_and_takeoff(aTargetAltitude):
 
     # Don't try to arm until autopilot is ready
     while not vehicle.is_armable:
-        print " Waiting for vehicle to initialise..."
+        print(" Waiting for vehicle to initialise...")
         time.sleep(1)
         
     # Set mode to GUIDED for arming and takeoff:
@@ -118,10 +119,10 @@ def arm_and_takeoff(aTargetAltitude):
     # Confirm vehicle armed before attempting to take off
     while not vehicle.armed:
         vehicle.armed = True
-        print " Waiting for arming..."
+        print(" Waiting for arming...")
         time.sleep(1)
 
-    print " Taking off!"
+    print(" Taking off!")
     vehicle.simple_takeoff(aTargetAltitude) # Take off to target altitude
 
     # Wait until the vehicle reaches a safe height 
@@ -130,16 +131,16 @@ def arm_and_takeoff(aTargetAltitude):
         requiredAlt = aTargetAltitude*0.95
         #Break and return from function just below target altitude.        
         if vehicle.location.global_relative_frame.alt>=requiredAlt: 
-            print " Reached target altitude of ~%f" % (aTargetAltitude)
+            print(" Reached target altitude of ~%f" % (aTargetAltitude))
             break
-        print " Altitude: %f < %f" % (vehicle.location.global_relative_frame.alt,
-                                      requiredAlt)
+        print(" Altitude: %f < %f" % (vehicle.location.global_relative_frame.alt,
+                                      requiredAlt))
         time.sleep(1)
 
 
 print("Generating waypoints from tlog...")
 messages = position_messages_from_tlog(args.tlog)
-print " Generated %d waypoints from tlog" % len(messages)
+print(" Generated %d waypoints from tlog" % len(messages))
 if len(messages) == 0:
     print("No position messages found in log")
     exit(0)
@@ -157,7 +158,7 @@ else:
     connection_string = sitl.connection_string()
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 
@@ -168,8 +169,7 @@ cmds.wait_ready()
 
 cmds = vehicle.commands
 cmds.clear()
-for i in xrange(0, len(messages)):
-    pt = messages[i]
+for pt in messages:
     #print "Point: %d %d" % (pt.lat, pt.lon,)
     lat = pt.lat
     lon = pt.lon
@@ -189,11 +189,11 @@ for i in xrange(0, len(messages)):
 print("Uploading %d waypoints to vehicle..." % len(messages))
 cmds.upload()
 
-print "Arm and Takeoff"
+print("Arm and Takeoff")
 arm_and_takeoff(30)
 
 
-print "Starting mission"
+print("Starting mission")
 
 # Reset mission set to first (0) waypoint
 vehicle.commands.next=0
@@ -207,20 +207,20 @@ while (vehicle.mode.name != "AUTO"):
 time_start = time.time()
 while time.time() - time_start < 60:
     nextwaypoint=vehicle.commands.next
-    print 'Distance to waypoint (%s): %s' % (nextwaypoint, distance_to_current_waypoint())
+    print('Distance to waypoint (%s): %s' % (nextwaypoint, distance_to_current_waypoint()))
 
     if nextwaypoint==len(messages):
-        print "Exit 'standard' mission when start heading to final waypoint"
+        print("Exit 'standard' mission when start heading to final waypoint")
         break;
     time.sleep(1)
 
-print 'Return to launch'
+print('Return to launch')
 while (vehicle.mode.name != "RTL"):
     vehicle.mode = VehicleMode("RTL")
     time.sleep(0.1)
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/follow_me/follow_me.py
+++ b/examples/follow_me/follow_me.py
@@ -13,6 +13,7 @@ When you want to stop follow-me, either change vehicle modes or type Ctrl+C to e
 
 Example documentation: http://python.dronekit.io/examples/follow_me.html
 """
+from __future__ import print_function
 
 from dronekit import connect, VehicleMode, LocationGlobalRelative
 import gps
@@ -38,7 +39,7 @@ if not connection_string:
     connection_string = sitl.connection_string()
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 
@@ -48,31 +49,31 @@ def arm_and_takeoff(aTargetAltitude):
     Arms vehicle and fly to aTargetAltitude.
     """
 
-    print "Basic pre-arm checks"
+    print("Basic pre-arm checks")
     # Don't let the user try to arm until autopilot is ready
     while not vehicle.is_armable:
-        print " Waiting for vehicle to initialise..."
+        print(" Waiting for vehicle to initialise...")
         time.sleep(1)
 
         
-    print "Arming motors"
+    print("Arming motors")
     # Copter should arm in GUIDED mode
     vehicle.mode = VehicleMode("GUIDED")
     vehicle.armed = True    
 
     while not vehicle.armed:      
-        print " Waiting for arming..."
+        print(" Waiting for arming...")
         time.sleep(1)
 
-    print "Taking off!"
+    print("Taking off!")
     vehicle.simple_takeoff(aTargetAltitude) # Take off to target altitude
 
     # Wait until the vehicle reaches a safe height before processing the goto (otherwise the command 
     #  after Vehicle.simple_takeoff will execute immediately).
     while True:
-        print " Altitude: ", vehicle.location.global_relative_frame.alt      
+        print(" Altitude: ", vehicle.location.global_relative_frame.alt)      
         if vehicle.location.global_relative_frame.alt>=aTargetAltitude*0.95: #Trigger just below target alt.
-            print "Reached target altitude"
+            print("Reached target altitude")
             break
         time.sleep(1)
 
@@ -88,17 +89,17 @@ try:
     while True:
     
         if vehicle.mode.name != "GUIDED":
-            print "User has changed flight modes - aborting follow-me"
+            print("User has changed flight modes - aborting follow-me")
             break    
             
         # Read the GPS state from the laptop
-        gpsd.next()
+        next(gpsd)
 
         # Once we have a valid location (see gpsd documentation) we can start moving our vehicle around
         if (gpsd.valid & gps.LATLON_SET) != 0:
             altitude = 30  # in meters
             dest = LocationGlobalRelative(gpsd.fix.latitude, gpsd.fix.longitude, altitude)
-            print "Going to: %s" % dest
+            print("Going to: %s" % dest)
 
             # A better implementation would only send new waypoints if the position had changed significantly
             vehicle.simple_goto(dest)
@@ -108,11 +109,11 @@ try:
             time.sleep(2)
             
 except socket.error:
-    print "Error: gpsd service does not seem to be running, plug in USB GPS or run run-fake-gps.sh"
+    print("Error: gpsd service does not seem to be running, plug in USB GPS or run run-fake-gps.sh")
     sys.exit(1)
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/gcs/microgcs.py
+++ b/examples/gcs/microgcs.py
@@ -4,6 +4,7 @@
 """
 © Copyright 2015-2016, 3D Robotics.
 """
+from __future__ import print_function
 #
 # This is a small example of the python drone API - an ultra minimal GCS
 #
@@ -32,7 +33,7 @@ if not connection_string:
     connection_string = sitl.connection_string()
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 def setMode(mode):

--- a/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
+++ b/examples/guided_set_speed_yaw/guided_set_speed_yaw.py
@@ -9,6 +9,7 @@ This example shows how to move/direct Copter and send commands in GUIDED mode us
 
 Example documentation: http://python.dronekit.io/examples/guided-set-speed-yaw-demo.html
 """
+from __future__ import print_function
 
 from dronekit import connect, VehicleMode, LocationGlobal, LocationGlobalRelative
 from pymavlink import mavutil # Needed for command message definitions
@@ -35,7 +36,7 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 
@@ -44,31 +45,31 @@ def arm_and_takeoff(aTargetAltitude):
     Arms vehicle and fly to aTargetAltitude.
     """
 
-    print "Basic pre-arm checks"
+    print("Basic pre-arm checks")
     # Don't let the user try to arm until autopilot is ready
     while not vehicle.is_armable:
-        print " Waiting for vehicle to initialise..."
+        print(" Waiting for vehicle to initialise...")
         time.sleep(1)
 
         
-    print "Arming motors"
+    print("Arming motors")
     # Copter should arm in GUIDED mode
     vehicle.mode = VehicleMode("GUIDED")
     vehicle.armed = True
 
     while not vehicle.armed:      
-        print " Waiting for arming..."
+        print(" Waiting for arming...")
         time.sleep(1)
 
-    print "Taking off!"
+    print("Taking off!")
     vehicle.simple_takeoff(aTargetAltitude) # Take off to target altitude
 
     # Wait until the vehicle reaches a safe height before processing the goto (otherwise the command 
     #  after Vehicle.simple_takeoff will execute immediately).
     while True:
-        print " Altitude: ", vehicle.location.global_relative_frame.alt      
+        print(" Altitude: ", vehicle.location.global_relative_frame.alt)      
         if vehicle.location.global_relative_frame.alt>=aTargetAltitude*0.95: #Trigger just below target alt.
-            print "Reached target altitude"
+            print("Reached target altitude")
             break
         time.sleep(1)
 
@@ -316,9 +317,9 @@ def goto(dNorth, dEast, gotoFunction=vehicle.simple_goto):
     while vehicle.mode.name=="GUIDED": #Stop action if we are no longer in guided mode.
         #print "DEBUG: mode: %s" % vehicle.mode.name
         remainingDistance=get_distance_metres(vehicle.location.global_relative_frame, targetLocation)
-        print "Distance to target: ", remainingDistance
+        print("Distance to target: ", remainingDistance)
         if remainingDistance<=targetDistance*0.01: #Just below target, in case of undershoot.
-            print "Reached target"
+            print("Reached target")
             break;
         time.sleep(2)
 
@@ -605,12 +606,12 @@ send_global_velocity(0,0,0,1)
 
 print("Set new home location to current location")
 vehicle.home_location=vehicle.location.global_frame
-print "Get new home location"
+print("Get new home location")
 #This reloads the home location in DroneKit and GCSs
 cmds = vehicle.commands
 cmds.download()
 cmds.wait_ready()
-print " Home Location: %s" % vehicle.home_location
+print(" Home Location: %s" % vehicle.home_location)
 
 
 print("Yaw 90 relative (to previous yaw heading)")
@@ -638,7 +639,7 @@ vehicle.mode = VehicleMode("LAND")
 
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/mission_basic/mission_basic.py
+++ b/examples/mission_basic/mission_basic.py
@@ -7,6 +7,7 @@ mission_basic.py: Example demonstrating basic mission operations including creat
 
 Full documentation is provided at http://python.dronekit.io/examples/mission_basic.html
 """
+from __future__ import print_function
 
 from dronekit import connect, VehicleMode, LocationGlobalRelative, LocationGlobal, Command
 import time
@@ -33,7 +34,7 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 
@@ -112,10 +113,10 @@ def adds_square_mission(aLocation, aSize):
 
     cmds = vehicle.commands
 
-    print " Clear any existing commands"
+    print(" Clear any existing commands")
     cmds.clear() 
     
-    print " Define/add new commands."
+    print(" Define/add new commands.")
     # Add new commands. The meaning/order of the parameters is documented in the Command class. 
      
     #Add MAV_CMD_NAV_TAKEOFF command. This is ignored if the vehicle is already in the air.
@@ -133,7 +134,7 @@ def adds_square_mission(aLocation, aSize):
     #add dummy waypoint "5" at point 4 (lets us know when have reached destination)
     cmds.add(Command( 0, 0, 0, mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT, mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 0, 0, 0, 0, point4.lat, point4.lon, 14))    
 
-    print " Upload new commands to vehicle"
+    print(" Upload new commands to vehicle")
     cmds.upload()
 
 
@@ -142,43 +143,43 @@ def arm_and_takeoff(aTargetAltitude):
     Arms vehicle and fly to aTargetAltitude.
     """
 
-    print "Basic pre-arm checks"
+    print("Basic pre-arm checks")
     # Don't let the user try to arm until autopilot is ready
     while not vehicle.is_armable:
-        print " Waiting for vehicle to initialise..."
+        print(" Waiting for vehicle to initialise...")
         time.sleep(1)
 
         
-    print "Arming motors"
+    print("Arming motors")
     # Copter should arm in GUIDED mode
     vehicle.mode = VehicleMode("GUIDED")
     vehicle.armed = True
 
     while not vehicle.armed:      
-        print " Waiting for arming..."
+        print(" Waiting for arming...")
         time.sleep(1)
 
-    print "Taking off!"
+    print("Taking off!")
     vehicle.simple_takeoff(aTargetAltitude) # Take off to target altitude
 
     # Wait until the vehicle reaches a safe height before processing the goto (otherwise the command 
     #  after Vehicle.simple_takeoff will execute immediately).
     while True:
-        print " Altitude: ", vehicle.location.global_relative_frame.alt      
+        print(" Altitude: ", vehicle.location.global_relative_frame.alt)      
         if vehicle.location.global_relative_frame.alt>=aTargetAltitude*0.95: #Trigger just below target alt.
-            print "Reached target altitude"
+            print("Reached target altitude")
             break
         time.sleep(1)
 
         
-print 'Create a new mission (for current location)'
+print('Create a new mission (for current location)')
 adds_square_mission(vehicle.location.global_frame,50)
 
 
 # From Copter 3.3 you will be able to take off using a mission item. Plane must take off using a mission item (currently).
 arm_and_takeoff(10)
 
-print "Starting mission"
+print("Starting mission")
 # Reset mission set to first (0) waypoint
 vehicle.commands.next=0
 
@@ -193,22 +194,22 @@ vehicle.mode = VehicleMode("AUTO")
 
 while True:
     nextwaypoint=vehicle.commands.next
-    print 'Distance to waypoint (%s): %s' % (nextwaypoint, distance_to_current_waypoint())
+    print('Distance to waypoint (%s): %s' % (nextwaypoint, distance_to_current_waypoint()))
   
     if nextwaypoint==3: #Skip to next waypoint
-        print 'Skipping to Waypoint 5 when reach waypoint 3'
+        print('Skipping to Waypoint 5 when reach waypoint 3')
         vehicle.commands.next = 5
     if nextwaypoint==5: #Dummy waypoint - as soon as we reach waypoint 4 this is true and we exit.
-        print "Exit 'standard' mission when start heading to final waypoint (5)"
+        print("Exit 'standard' mission when start heading to final waypoint (5)")
         break;
     time.sleep(1)
 
-print 'Return to launch'
+print('Return to launch')
 vehicle.mode = VehicleMode("RTL")
 
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/examples/mission_import_export/mission_import_export.py
+++ b/examples/mission_import_export/mission_import_export.py
@@ -11,6 +11,7 @@ into a list, and can be modified before saving and/or uploading.
 
 Documentation is provided at http://python.dronekit.io/examples/mission_import_export.html
 """
+from __future__ import print_function
 
 
 from dronekit import connect, Command
@@ -36,14 +37,14 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 # Check that vehicle is armable. 
 # This ensures home_location is set (needed when saving WP file)
 
 while not vehicle.is_armable:
-    print " Waiting for vehicle to initialise..."
+    print(" Waiting for vehicle to initialise...")
     time.sleep(1)
 
 
@@ -54,7 +55,7 @@ def readmission(aFileName):
 
     This function is used by upload_mission().
     """
-    print "\nReading mission from file: %s" % aFileName
+    print("\nReading mission from file: %s" % aFileName)
     cmds = vehicle.commands
     missionlist=[]
     with open(aFileName) as f:
@@ -88,15 +89,15 @@ def upload_mission(aFileName):
     #Read mission from file
     missionlist = readmission(aFileName)
     
-    print "\nUpload mission from a file: %s" % import_mission_filename
+    print("\nUpload mission from a file: %s" % import_mission_filename)
     #Clear existing mission from vehicle
-    print ' Clear mission'
+    print(' Clear mission')
     cmds = vehicle.commands
     cmds.clear()
     #Add new mission to vehicle
     for command in missionlist:
         cmds.add(command)
-    print ' Upload mission'
+    print(' Upload mission')
     vehicle.commands.upload()
 
 
@@ -105,7 +106,7 @@ def download_mission():
     Downloads the current mission and returns it in a list.
     It is used in save_mission() to get the file information to save.
     """
-    print " Download mission from vehicle"
+    print(" Download mission from vehicle")
     missionlist=[]
     cmds = vehicle.commands
     cmds.download()
@@ -119,7 +120,7 @@ def save_mission(aFileName):
     Save a mission in the Waypoint file format 
     (http://qgroundcontrol.org/mavlink/waypoint_protocol#waypoint_file_format).
     """
-    print "\nSave mission from Vehicle to file: %s" % export_mission_filename    
+    print("\nSave mission from Vehicle to file: %s" % export_mission_filename)    
     #Download mission from vehicle
     missionlist = download_mission()
     #Add file-format information
@@ -132,7 +133,7 @@ def save_mission(aFileName):
         commandline="%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" % (cmd.seq,cmd.current,cmd.frame,cmd.command,cmd.param1,cmd.param2,cmd.param3,cmd.param4,cmd.x,cmd.y,cmd.z,cmd.autocontinue)
         output+=commandline
     with open(aFileName, 'w') as file_:
-        print " Write mission to file"
+        print(" Write mission to file")
         file_.write(output)
         
         
@@ -140,10 +141,10 @@ def printfile(aFileName):
     """
     Print a mission file to demonstrate "round trip"
     """
-    print "\nMission file: %s" % aFileName
+    print("\nMission file: %s" % aFileName)
     with open(aFileName) as f:
         for line in f:
-            print ' %s' % line.strip()        
+            print(' %s' % line.strip())        
 
 
 import_mission_filename = 'mpmission.txt'
@@ -157,7 +158,7 @@ upload_mission(import_mission_filename)
 save_mission(export_mission_filename)
 
 #Close vehicle object before exiting script
-print "Close vehicle object"
+print("Close vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.
@@ -165,7 +166,7 @@ if sitl is not None:
     sitl.stop()
 
 
-print "\nShow original and uploaded/downloaded files:"
+print("\nShow original and uploaded/downloaded files:")
 #Print original file (for demo purposes only)
 printfile(import_mission_filename)
 #Print exported file (for demo purposes only)

--- a/examples/performance_test/performance_test.py
+++ b/examples/performance_test/performance_test.py
@@ -12,6 +12,7 @@ minimum, and most recent interval for 30 seconds.
 
 Full documentation is provided at http://python.dronekit.io/examples/performance_test.html
 """
+from __future__ import print_function
 from dronekit import connect
 from pymavlink import mavutil
 import time
@@ -36,7 +37,7 @@ if not connection_string:
 
 
 # Connect to the Vehicle
-print 'Connecting to vehicle on: %s' % connection_string
+print('Connecting to vehicle on: %s' % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 #global vehicle
@@ -107,7 +108,7 @@ def send_testpackets():
 #Start logging by sending a test packet
 send_testpackets()
 
-print "Logging for 30 seconds"
+print("Logging for 30 seconds")
 for x in range(1,30):
     time.sleep(1)
 

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -10,6 +10,7 @@ and how to observe vehicle attribute (state) changes.
 
 Full documentation is provided at http://python.dronekit.io/examples/vehicle_state.html
 """
+from __future__ import print_function
 from dronekit import connect, VehicleMode
 import time
 
@@ -33,55 +34,55 @@ if not connection_string:
 
 # Connect to the Vehicle. 
 #   Set `wait_ready=True` to ensure default attributes are populated before `connect()` returns.
-print "\nConnecting to vehicle on: %s" % connection_string
+print("\nConnecting to vehicle on: %s" % connection_string)
 vehicle = connect(connection_string, wait_ready=True)
 
 vehicle.wait_ready('autopilot_version')
 
 # Get all vehicle attributes (state)
-print "\nGet all vehicle attribute values:"
-print " Autopilot Firmware version: %s" % vehicle.version
-print "   Major version number: %s" % vehicle.version.major
-print "   Minor version number: %s" % vehicle.version.minor
-print "   Patch version number: %s" % vehicle.version.patch
-print "   Release type: %s" % vehicle.version.release_type()
-print "   Release version: %s" % vehicle.version.release_version()
-print "   Stable release?: %s" % vehicle.version.is_stable()
-print " Autopilot capabilities"
-print "   Supports MISSION_FLOAT message type: %s" % vehicle.capabilities.mission_float
-print "   Supports PARAM_FLOAT message type: %s" % vehicle.capabilities.param_float
-print "   Supports MISSION_INT message type: %s" % vehicle.capabilities.mission_int
-print "   Supports COMMAND_INT message type: %s" % vehicle.capabilities.command_int
-print "   Supports PARAM_UNION message type: %s" % vehicle.capabilities.param_union
-print "   Supports ftp for file transfers: %s" % vehicle.capabilities.ftp
-print "   Supports commanding attitude offboard: %s" % vehicle.capabilities.set_attitude_target
-print "   Supports commanding position and velocity targets in local NED frame: %s" % vehicle.capabilities.set_attitude_target_local_ned
-print "   Supports set position + velocity targets in global scaled integers: %s" % vehicle.capabilities.set_altitude_target_global_int
-print "   Supports terrain protocol / data handling: %s" % vehicle.capabilities.terrain
-print "   Supports direct actuator control: %s" % vehicle.capabilities.set_actuator_target
-print "   Supports the flight termination command: %s" % vehicle.capabilities.flight_termination
-print "   Supports mission_float message type: %s" % vehicle.capabilities.mission_float
-print "   Supports onboard compass calibration: %s" % vehicle.capabilities.compass_calibration
-print " Global Location: %s" % vehicle.location.global_frame
-print " Global Location (relative altitude): %s" % vehicle.location.global_relative_frame
-print " Local Location: %s" % vehicle.location.local_frame
-print " Attitude: %s" % vehicle.attitude
-print " Velocity: %s" % vehicle.velocity
-print " GPS: %s" % vehicle.gps_0
-print " Gimbal status: %s" % vehicle.gimbal
-print " Battery: %s" % vehicle.battery
-print " EKF OK?: %s" % vehicle.ekf_ok
-print " Last Heartbeat: %s" % vehicle.last_heartbeat
-print " Rangefinder: %s" % vehicle.rangefinder
-print " Rangefinder distance: %s" % vehicle.rangefinder.distance
-print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
-print " Heading: %s" % vehicle.heading
-print " Is Armable?: %s" % vehicle.is_armable
-print " System status: %s" % vehicle.system_status.state
-print " Groundspeed: %s" % vehicle.groundspeed    # settable
-print " Airspeed: %s" % vehicle.airspeed    # settable
-print " Mode: %s" % vehicle.mode.name    # settable
-print " Armed: %s" % vehicle.armed    # settable
+print("\nGet all vehicle attribute values:")
+print(" Autopilot Firmware version: %s" % vehicle.version)
+print("   Major version number: %s" % vehicle.version.major)
+print("   Minor version number: %s" % vehicle.version.minor)
+print("   Patch version number: %s" % vehicle.version.patch)
+print("   Release type: %s" % vehicle.version.release_type())
+print("   Release version: %s" % vehicle.version.release_version())
+print("   Stable release?: %s" % vehicle.version.is_stable())
+print(" Autopilot capabilities")
+print("   Supports MISSION_FLOAT message type: %s" % vehicle.capabilities.mission_float)
+print("   Supports PARAM_FLOAT message type: %s" % vehicle.capabilities.param_float)
+print("   Supports MISSION_INT message type: %s" % vehicle.capabilities.mission_int)
+print("   Supports COMMAND_INT message type: %s" % vehicle.capabilities.command_int)
+print("   Supports PARAM_UNION message type: %s" % vehicle.capabilities.param_union)
+print("   Supports ftp for file transfers: %s" % vehicle.capabilities.ftp)
+print("   Supports commanding attitude offboard: %s" % vehicle.capabilities.set_attitude_target)
+print("   Supports commanding position and velocity targets in local NED frame: %s" % vehicle.capabilities.set_attitude_target_local_ned)
+print("   Supports set position + velocity targets in global scaled integers: %s" % vehicle.capabilities.set_altitude_target_global_int)
+print("   Supports terrain protocol / data handling: %s" % vehicle.capabilities.terrain)
+print("   Supports direct actuator control: %s" % vehicle.capabilities.set_actuator_target)
+print("   Supports the flight termination command: %s" % vehicle.capabilities.flight_termination)
+print("   Supports mission_float message type: %s" % vehicle.capabilities.mission_float)
+print("   Supports onboard compass calibration: %s" % vehicle.capabilities.compass_calibration)
+print(" Global Location: %s" % vehicle.location.global_frame)
+print(" Global Location (relative altitude): %s" % vehicle.location.global_relative_frame)
+print(" Local Location: %s" % vehicle.location.local_frame)
+print(" Attitude: %s" % vehicle.attitude)
+print(" Velocity: %s" % vehicle.velocity)
+print(" GPS: %s" % vehicle.gps_0)
+print(" Gimbal status: %s" % vehicle.gimbal)
+print(" Battery: %s" % vehicle.battery)
+print(" EKF OK?: %s" % vehicle.ekf_ok)
+print(" Last Heartbeat: %s" % vehicle.last_heartbeat)
+print(" Rangefinder: %s" % vehicle.rangefinder)
+print(" Rangefinder distance: %s" % vehicle.rangefinder.distance)
+print(" Rangefinder voltage: %s" % vehicle.rangefinder.voltage)
+print(" Heading: %s" % vehicle.heading)
+print(" Is Armable?: %s" % vehicle.is_armable)
+print(" System status: %s" % vehicle.system_status.state)
+print(" Groundspeed: %s" % vehicle.groundspeed)    # settable
+print(" Airspeed: %s" % vehicle.airspeed)    # settable
+print(" Mode: %s" % vehicle.mode.name)    # settable
+print(" Armed: %s" % vehicle.armed)    # settable
 
 
 
@@ -91,38 +92,38 @@ while not vehicle.home_location:
     cmds.download()
     cmds.wait_ready()
     if not vehicle.home_location:
-        print " Waiting for home location ..."
+        print(" Waiting for home location ...")
 # We have a home location, so print it!        
-print "\n Home location: %s" % vehicle.home_location
+print("\n Home location: %s" % vehicle.home_location)
 
 
 # Set vehicle home_location, mode, and armed attributes (the only settable attributes)
 
-print "\nSet new home location"
+print("\nSet new home location")
 # Home location must be within 50km of EKF home location (or setting will fail silently)
 # In this case, just set value to current location with an easily recognisable altitude (222)
 my_location_alt = vehicle.location.global_frame
 my_location_alt.alt = 222.0
 vehicle.home_location = my_location_alt
-print " New Home Location (from attribute - altitude should be 222): %s" % vehicle.home_location
+print(" New Home Location (from attribute - altitude should be 222): %s" % vehicle.home_location)
 
 #Confirm current value on vehicle by re-downloading commands
 cmds = vehicle.commands
 cmds.download()
 cmds.wait_ready()
-print " New Home Location (from vehicle - altitude should be 222): %s" % vehicle.home_location
+print(" New Home Location (from vehicle - altitude should be 222): %s" % vehicle.home_location)
 
 
-print "\nSet Vehicle.mode = GUIDED (currently: %s)" % vehicle.mode.name 
+print("\nSet Vehicle.mode = GUIDED (currently: %s)" % vehicle.mode.name) 
 vehicle.mode = VehicleMode("GUIDED")
 while not vehicle.mode.name=='GUIDED':  #Wait until mode has changed
-    print " Waiting for mode change ..."
+    print(" Waiting for mode change ...")
     time.sleep(1)
 
 
 # Check that vehicle is armable
 while not vehicle.is_armable:
-    print " Waiting for vehicle to initialise..."
+    print(" Waiting for vehicle to initialise...")
     time.sleep(1)
     # If required, you can provide additional information about initialisation
     # using `vehicle.gps_0.fix_type` and `vehicle.mode.name`.
@@ -146,87 +147,87 @@ def attitude_callback(self, attr_name, value):
     global last_attitude_cache
     # Only publish when value changes
     if value!=last_attitude_cache:
-        print " CALLBACK: Attitude changed to", value
+        print(" CALLBACK: Attitude changed to", value)
         last_attitude_cache=value
 
-print "\nAdd `attitude` attribute callback/observer on `vehicle`"     
+print("\nAdd `attitude` attribute callback/observer on `vehicle`")     
 vehicle.add_attribute_listener('attitude', attitude_callback)
 
-print " Wait 2s so callback invoked before observer removed"
+print(" Wait 2s so callback invoked before observer removed")
 time.sleep(2)
 
-print " Remove Vehicle.attitude observer"    
+print(" Remove Vehicle.attitude observer")    
 # Remove observer added with `add_attribute_listener()` specifying the attribute and callback function
 vehicle.remove_attribute_listener('attitude', attitude_callback)
 
 
         
 # Add mode attribute callback using decorator (callbacks added this way cannot be removed).
-print "\nAdd `mode` attribute callback/observer using decorator" 
+print("\nAdd `mode` attribute callback/observer using decorator") 
 @vehicle.on_attribute('mode')   
 def decorated_mode_callback(self, attr_name, value):
     # `attr_name` is the observed attribute (used if callback is used for multiple attributes)
     # `attr_name` - the observed attribute (used if callback is used for multiple attributes)
     # `value` is the updated attribute value.
-    print " CALLBACK: Mode changed to", value
+    print(" CALLBACK: Mode changed to", value)
 
-print " Set mode=STABILIZE (currently: %s) and wait for callback" % vehicle.mode.name 
+print(" Set mode=STABILIZE (currently: %s) and wait for callback" % vehicle.mode.name) 
 vehicle.mode = VehicleMode("STABILIZE")
 
-print " Wait 2s so callback invoked before moving to next example"
+print(" Wait 2s so callback invoked before moving to next example")
 time.sleep(2)
 
-print "\n Attempt to remove observer added with `on_attribute` decorator (should fail)" 
+print("\n Attempt to remove observer added with `on_attribute` decorator (should fail)") 
 try:
     vehicle.remove_attribute_listener('mode', decorated_mode_callback)
 except:
-    print " Exception: Cannot remove observer added using decorator"
+    print(" Exception: Cannot remove observer added using decorator")
 
 
 
  
 # Demonstrate getting callback on any attribute change
 def wildcard_callback(self, attr_name, value):
-    print " CALLBACK: (%s): %s" % (attr_name,value)
+    print(" CALLBACK: (%s): %s" % (attr_name,value))
 
-print "\nAdd attribute callback detecting ANY attribute change"     
+print("\nAdd attribute callback detecting ANY attribute change")     
 vehicle.add_attribute_listener('*', wildcard_callback)
 
 
-print " Wait 1s so callback invoked before observer removed"
+print(" Wait 1s so callback invoked before observer removed")
 time.sleep(1)
 
-print " Remove Vehicle attribute observer"    
+print(" Remove Vehicle attribute observer")    
 # Remove observer added with `add_attribute_listener()`
 vehicle.remove_attribute_listener('*', wildcard_callback)
     
 
 
 # Get/Set Vehicle Parameters
-print "\nRead and write parameters"
-print " Read vehicle param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
+print("\nRead and write parameters")
+print(" Read vehicle param 'THR_MIN': %s" % vehicle.parameters['THR_MIN'])
 
-print " Write vehicle param 'THR_MIN' : 10"
+print(" Write vehicle param 'THR_MIN' : 10")
 vehicle.parameters['THR_MIN']=10
-print " Read new value of param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
+print(" Read new value of param 'THR_MIN': %s" % vehicle.parameters['THR_MIN'])
 
 
-print "\nPrint all parameters (iterate `vehicle.parameters`):"
+print("\nPrint all parameters (iterate `vehicle.parameters`):")
 for key, value in vehicle.parameters.iteritems():
-    print " Key:%s Value:%s" % (key,value)
+    print(" Key:%s Value:%s" % (key,value))
     
 
-print "\nCreate parameter observer using decorator"
+print("\nCreate parameter observer using decorator")
 # Parameter string is case-insensitive
 # Value is cached (listeners are only updated on change)
 # Observer added using decorator can't be removed.
  
 @vehicle.parameters.on_attribute('THR_MIN')  
 def decorated_thr_min_callback(self, attr_name, value):
-    print " PARAMETER CALLBACK: %s changed to: %s" % (attr_name, value)
+    print(" PARAMETER CALLBACK: %s changed to: %s" % (attr_name, value))
 
 
-print "Write vehicle param 'THR_MIN' : 20 (and wait for callback)"
+print("Write vehicle param 'THR_MIN' : 20 (and wait for callback)")
 vehicle.parameters['THR_MIN']=20
 for x in range(1,5):
     #Callbacks may not be updated for a few seconds
@@ -236,19 +237,19 @@ for x in range(1,5):
 
 
 #Callback function for "any" parameter
-print "\nCreate (removable) observer for any parameter using wildcard string"
+print("\nCreate (removable) observer for any parameter using wildcard string")
 def any_parameter_callback(self, attr_name, value):
-    print " ANY PARAMETER CALLBACK: %s changed to: %s" % (attr_name, value)
+    print(" ANY PARAMETER CALLBACK: %s changed to: %s" % (attr_name, value))
 
 #Add observer for the vehicle's any/all parameters parameter (defined using wildcard string ``'*'``)
 vehicle.parameters.add_attribute_listener('*', any_parameter_callback)     
-print " Change THR_MID and THR_MIN parameters (and wait for callback)"    
+print(" Change THR_MID and THR_MIN parameters (and wait for callback)")    
 vehicle.parameters['THR_MID']=400  
 vehicle.parameters['THR_MIN']=30
 
 
 ## Reset variables to sensible values.
-print "\nReset vehicle attributes/parameters and exit"
+print("\nReset vehicle attributes/parameters and exit")
 vehicle.mode = VehicleMode("STABILIZE")
 #vehicle.armed = False
 vehicle.parameters['THR_MIN']=130
@@ -256,7 +257,7 @@ vehicle.parameters['THR_MID']=500
 
 
 #Close vehicle object before exiting script
-print "\nClose vehicle object"
+print("\nClose vehicle object")
 vehicle.close()
 
 # Shut down simulator if it was started.

--- a/windows/returnVersion.py
+++ b/windows/returnVersion.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This script reads the setup.py and returns the current version number
 # Used as part of building the WIndows setup file (DronekitWinBuild.bat)
 # It assumes there is a line like this:
@@ -8,5 +9,5 @@ with open("../setup.py") as f:
     searchlines = f.readlines()
     for i, line in enumerate(searchlines):
         if "version = " in line: 
-            print line[11:len(line)-2]
+            print(line[11:len(line)-2])
             break


### PR DESCRIPTION
This PR replaces #750 and uses http://python-future.org code to do a more complete job than 750.

Make the minimal, safe changes required to convert the code to be syntax compatible with both Python 2 and Python 3. There would definitely be [__more work required__](https://travis-ci.org/dronekit/dronekit-python/jobs/275427857#L1608) to complete the port of the code to Python 3 but this is a minimal, safe first step.

1. Run: `futurize --stage1 -w **/*.py`

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`

2. Remove the need for xrange() in `examples/flight_replay/flight_replay.py`
3. Do better testing on Python 3 in allow_failures mode in `.travis.yml`