### PR TITLE
Add support for Optical Flow and Rangefinder to guide the vehicle indoors

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1766,7 +1766,7 @@ class Vehicle(HasObservers):
         return self.mode != 'INITIALISING' and self.gps_0.fix_type > 1 and self._ekf_predposhorizabs
 
     @property
-	def is_armable_indoor(self):
+    def is_armable_indoor(self):
         """
         Returns ``True`` if the vehicle is ready to arm, false otherwise (``Boolean``).
 
@@ -1775,7 +1775,7 @@ class Vehicle(HasObservers):
         This attribute is intended for indoor applications with optical flow and rangefinder.
         """
         # check that the mode is not INITIALISING
-		# check that rangefinder is working
+        # check that rangefinder is working
         # check that EKF pre-arm for optical flow sensor is complete
         return self.mode != 'INITIALISING' and self.rangefinder.distance and self._ekf_predposhorizrel
 


### PR DESCRIPTION
I modified the code to support guiding a copter with **Optical Flow** and **Rangefinder** indoors. 

I created a new pre-flight check to suite the OF+RF indoor environment. I added a message listener for ``EKF_PRED_POS_HORIZ_REL`` and an ``is_armable_indoor`` attribute in class Vehicle. ``EKF_PRED_POS_HORIZ_REL`` will be ``True`` when the Optical Flow and Rangefinder are providing good data. And ``is_armable_indoor`` is intended to take the place of ``is_armable`` attribute when guiding the copter indoors. 

**NOTE that setting a home position manually is necessary before taking off**. After that, we can command the vehicle to switch to GUIDED, arm, takeoff and doing other things just as if it has a GPS fix outdoors.