### PR TITLE
Travis: enforce critical flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - SITL_RATE=200
 
 python:
-  - 2.7.13
+  - 2.7
   - 3.6
 
 before_install:
@@ -17,10 +17,10 @@ install:
   - pip install flake8
 
 before_script:
-  # --exit-zero means that flake8 will not stop the build
-  # 127 characters is the width of a GitHub editor
-  - flake8 . --count --exit-zero  --max-line-length=127 --select=E999 --statistics  # syntax errors
-  - flake8 . --count --exit-zero  --max-line-length=127 --statistics
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - nosetests --debug=nose,nose.importer --debug-log=nose_debug -svx dronekit.test.unit


### PR DESCRIPTION
* Now that the Travis default Python 2.7 is Python 2.7.13, remove the microversion so we can get upgraded when Travis upgrades