### PR TITLE
Fixes and improvements for two SITL tests

### DIFF
--- a/dronekit/test/sitl/test_mavlink.py
+++ b/dronekit/test/sitl/test_mavlink.py
@@ -8,12 +8,12 @@ from nose.tools import assert_not_equals, assert_equals
 
 @with_sitl
 def test_mavlink(connpath):
-    vehicle = connect(connpath)
+    vehicle = connect(connpath, wait_ready=True)
     out = MAVConnection('udpin:localhost:15668')
     vehicle._handler.pipe(out)
     out.start()
 
-    vehicle2 = connect('udpout:localhost:15668')
+    vehicle2 = connect('udpout:localhost:15668', wait_ready=True)
 
     result = {'success': False}
 
@@ -24,5 +24,6 @@ def test_mavlink(connpath):
     i = 20
     while not result['success'] and i > 0:
         time.sleep(1)
+        i -= 1
 
     assert result['success']

--- a/dronekit/test/sitl/test_parameters.py
+++ b/dronekit/test/sitl/test_parameters.py
@@ -50,7 +50,7 @@ def test_setting(connpath):
 
     @vehicle.parameters.on_attribute('THR_MIN')
     def listener(self, name, value):
-        result['success'] = name == 'THR_MIN' and value == 3.000
+        result['success'] = (name == 'THR_MIN' and value == 3.000)
 
     vehicle.parameters['THR_MIN'] = 3.000
 


### PR DESCRIPTION
Sometimes the SITL tests in `test_mavlink.py` fail because the vehicles are not ready.
We can avoid this by adding `wait_ready=True` to the `Vehicle.connect()` call and obtain more reliable result.

Also, a timeout condition would never activate because a counter was not decreased when it should have to.

In `test_parameters.py`, I added parentheses to make the assignment more legible.

This pull request contains the non-Python3-compatibility fixes from #784.