### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1290,7 +1290,7 @@ class Vehicle(HasObservers):
                 c = 0
                 for i, v in enumerate(self._params_set):
                     if v == None:
-                        self._master.mav.param_request_read_send(0, 0, b'', i)
+                        self._master.mav.param_request_read_send(0, 0, '', i)
                         c += 1
                         if c > 50:
                             break
@@ -1317,11 +1317,8 @@ class Vehicle(HasObservers):
                         self._params_duration = start_duration
                     self._params_set[msg.param_index] = msg
 
-                # Normalize parameter name (convert to string)
-                param_name = msg.param_id.decode('utf8')
-
-                self._params_map[param_name] = msg.param_value
-                self._parameters.notify_attribute_listeners(param_name, msg.param_value,
+                self._params_map[msg.param_id] = msg.param_value
+                self._parameters.notify_attribute_listeners(msg.param_id, msg.param_value,
                                                             cache=True)
             except:
                 import traceback
@@ -3000,7 +2997,7 @@ def connect(ip,
 
         @vehicle.on_message('STATUSTEXT')
         def listener(self, name, m):
-            status_printer(re.sub(r'(^|\n)', '>>> ', m.text.decode('utf-8').rstrip()))
+            status_printer(re.sub(r'(^|\n)', '>>> ', m.text.rstrip()))
 
     if _initialize:
         vehicle.initialize(rate=rate, heartbeat_timeout=heartbeat_timeout)

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1317,8 +1317,8 @@ class Vehicle(HasObservers):
                         self._params_duration = start_duration
                     self._params_set[msg.param_index] = msg
 
-                # Normalize parameter name (remove trailing null bytes and convert to string)
-                param_name = msg.param_id.rstrip(b'\x00').decode('utf8')
+                # Normalize parameter name (convert to string)
+                param_name = msg.param_id.decode('utf8')
 
                 self._params_map[param_name] = msg.param_value
                 self._parameters.notify_attribute_listeners(param_name, msg.param_value,
@@ -3000,7 +3000,7 @@ def connect(ip,
 
         @vehicle.on_message('STATUSTEXT')
         def listener(self, name, m):
-            status_printer(re.sub(r'(^|\n)', '>>> ', m.text.rstrip(b'\x00').decode('utf-8').rstrip()))
+            status_printer(re.sub(r'(^|\n)', '>>> ', m.text.decode('utf-8').rstrip()))
 
     if _initialize:
         vehicle.initialize(rate=rate, heartbeat_timeout=heartbeat_timeout)

--- a/dronekit/test/sitl/test_channels.py
+++ b/dronekit/test/sitl/test_channels.py
@@ -10,7 +10,7 @@ def assert_readback(vehicle, values):
     while i > 0:
         time.sleep(.1)
         i -= .1
-        for k, v in values.iteritems():
+        for k, v in values.items():
             if vehicle.channels[k] != v:
                 continue
         break
@@ -135,7 +135,7 @@ def test_timeout(connpath):
     # Set Ch2 to 33, clear channel 6
     vehicle.channels.overrides = {'2': 33, '6': None}
     assert_readback(vehicle, {'2': 33, '6': 1500})
-    assert_equals(vehicle.channels.overrides.keys(), ['2'])
+    assert_equals(list(vehicle.channels.overrides.keys()), ['2'])
 
     # Callbacks
     result = {'success': False}

--- a/dronekit/test/sitl/test_parameters.py
+++ b/dronekit/test/sitl/test_parameters.py
@@ -32,7 +32,7 @@ def test_iterating(connpath):
     vehicle = connect(connpath, wait_ready=True)
 
     # Iterate over parameters.
-    for k, v in vehicle.parameters.iteritems():
+    for k, v in vehicle.parameters.items():
         break
     for key in vehicle.parameters:
         break


### PR DESCRIPTION
This PR contains all the changes needed to make the tests pass under Python 3 (together with a [patch](https://github.com/ArduPilot/pymavlink/pull/141) in pymavlink).

Python 2 compatibility should be maintained (the tests continue to pass in Python 2).

Per @peterbarker advice, this PR contains *only* the Python 3-specific fixes from PR #784, which is superseded. The other fixes are in #788.