### PR TITLE
Fix param read loop for python 3

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1166,6 +1166,9 @@ class Vehicle(HasObservers):
         @self.on_message(['WAYPOINT_CURRENT', 'MISSION_CURRENT'])
         def listener(self, name, m):
             self._current_waypoint = m.seq
+            if m.seq != self._current_waypoint:
+                 self._current_waypoint = m.seq
+                 self.notify_attribute_listeners('commands.next',self._current_waypoint)
 
         self._ekf_poshorizabs = False
         self._ekf_constposmode = False

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1290,7 +1290,7 @@ class Vehicle(HasObservers):
                 c = 0
                 for i, v in enumerate(self._params_set):
                     if v == None:
-                        self._master.mav.param_request_read_send(0, 0, '', i)
+                        self._master.mav.param_request_read_send(0, 0, bytes(), i)
                         c += 1
                         if c > 50:
                             break


### PR DESCRIPTION
This commit changes the 'blank parameter ID' value from empty string to empty bytes, so that it can be packed for transmission to the copter in Python 3.