### PR TITLE
circle.yml: use latest available Python versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.13 3.6.0
+    - pyenv global 2.7.12 3.6.2
   environment:
     SITL_SPEEDUP: 10
     SITL_RATE: 200


### PR DESCRIPTION
Currently the CircleCI build is [failing](https://circleci.com/gh/dronekit/dronekit-python/1341) because Python 2.7.13 is not installed on the system image. Here is a list of available Python versions: https://circleci.com/docs/1.0/build-image-trusty/#python

This PR should fix that problem.

