### PR TITLE
circle.yml: fix Python versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.12 3.6.2
+    - pyenv global 2.7.10 3.5.0
   environment:
     SITL_SPEEDUP: 10
     SITL_RATE: 200


### PR DESCRIPTION
Correct version of [previous PR](807): these Python versions should work, or at least they did in [this commit](https://github.com/dronekit/dronekit-python/commit/fb004baddbedc510e17726474e8c40af88ccb208). This should fix the CircleCI build (again...)