### PR TITLE
CircleCI: fix the build (again...)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,9 @@ machine:
 
 dependencies:
   override:
-    - 'pip install . -UI'
+    - 'pip install -UI future'
     - 'pip install -r requirements.txt -UI'
+    - 'pip install . -UI'
 
 test:
   override:


### PR DESCRIPTION
- Install future beforehand as workaround to pymavlink bug: https://github.com/ArduPilot/pymavlink/issues/25
- Install dependencies before dronekit, not after

I tested this on my CircleCI so it should work. :-)