### PR TITLE
Autopilot reboot + test

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2360,6 +2360,21 @@ class Vehicle(HasObservers):
 
         return True
 
+    def reboot(self):
+        """Requests an autopilot reboot by sending a ``MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`` command."""
+
+        reboot_msg = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,  # command
+            0,  # confirmation
+            1,  # param 1, autopilot (reboot)
+            0,  # param 2, onboard computer (do nothing)
+            0,  # param 3, camera (do nothing)
+            0,  # param 4, mount (do nothing)
+            0, 0, 0)  # param 5 ~ 7 not used
+
+        self.send_mavlink(reboot_msg)
+
 
 class Gimbal(object):
     """

--- a/dronekit/test/sitl/test_reboot.py
+++ b/dronekit/test/sitl/test_reboot.py
@@ -1,0 +1,27 @@
+from nose.tools import assert_equal
+
+from dronekit import connect
+from dronekit.test import with_sitl
+import time
+
+
+@with_sitl
+def test_reboot(connpath):
+    """Tries to reboot the vehicle, and checks that the autopilot ACKs the command."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    reboot_acks = []
+
+    def on_ack(self, name, message):
+        if message.command == 246:  # reboot/shutdown
+            reboot_acks.append(message)
+
+    vehicle.add_message_listener('COMMAND_ACK', on_ack)
+    vehicle.reboot()
+    time.sleep(0.5)
+    vehicle.remove_message_listener('COMMAND_ACK', on_ack)
+
+    assert_equal(1, len(reboot_acks))  # one and only one ACK
+    assert_equal(246, reboot_acks[0].command)  # for the correct command
+    assert_equal(0, reboot_acks[0].result)  # the result must be successful


### PR DESCRIPTION
This PR implements a simple to use `Vehicle.reboot()` command to reboot the autopilot via software by sending a `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`.

I tested it on a Pixfalcon running PX4 and it works as expected.
The SITL doesn't support a real "reboot", but it still ACKs the command to the client. I added a test for that.