### PR TITLE
disable docs deploy from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,11 @@ workflows:
     jobs:
       - python2
 #      - python3
-      - deploy:
-          requires:
-            - python2
-          filters:
-            branches:
-              only:
-                - master
+#      disabling until we find a new docs server
+#      - deploy:
+#          requires:
+#            - python2
+#          filters:
+#            branches:
+#              only:
+#                - master


### PR DESCRIPTION
we are migrating service providers and need to disable deployments of
docs