### PR TITLE
Properly close Vehicle instances after SITL tests

### DIFF
--- a/dronekit/test/sitl/test_capability_and_version.py
+++ b/dronekit/test/sitl/test_capability_and_version.py
@@ -34,3 +34,5 @@ def test_115(connpath):
     assert_true(v.version.major is not None)
     assert_true(len(v.version.release_type()) >= 2)
     assert_true(v.version.release_version() is not None)
+
+    v.close()

--- a/dronekit/test/sitl/test_locations.py
+++ b/dronekit/test/sitl/test_locations.py
@@ -83,3 +83,5 @@ def test_location_notify(connpath):
     wait_for(lambda : ret['success'], 30)
 
     assert ret['success'], 'Expected location object to emit notifications.'
+
+    vehicle.close()

--- a/dronekit/test/sitl/test_mavlink.py
+++ b/dronekit/test/sitl/test_mavlink.py
@@ -27,3 +27,6 @@ def test_mavlink(connpath):
         i -= 1
 
     assert result['success']
+
+    vehicle2.close()
+    vehicle.close()

--- a/dronekit/test/sitl/test_mode_settings.py
+++ b/dronekit/test/sitl/test_mode_settings.py
@@ -13,3 +13,5 @@ def test_modes_set(connpath):
         assert_equals('STABILIZE', self._flightmode)
 
     vehicle.add_message_listener('HEARTBEAT', listener)
+
+    vehicle.close()

--- a/dronekit/test/sitl/test_reboot.py
+++ b/dronekit/test/sitl/test_reboot.py
@@ -25,3 +25,5 @@ def test_reboot(connpath):
     assert_equal(1, len(reboot_acks))  # one and only one ACK
     assert_equal(246, reboot_acks[0].command)  # for the correct command
     assert_equal(0, reboot_acks[0].result)  # the result must be successful
+
+    vehicle.close()

--- a/dronekit/test/sitl/test_state.py
+++ b/dronekit/test/sitl/test_state.py
@@ -13,3 +13,5 @@ def test_state(connpath):
 
     assert_equals(type(vehicle.system_status), SystemStatus)
     assert_equals(type(vehicle.system_status.state), str)
+
+    vehicle.close()

--- a/dronekit/test/sitl/test_timeout.py
+++ b/dronekit/test/sitl/test_timeout.py
@@ -35,6 +35,8 @@ def test_timeout_empty():
         # Connect with timeout of 10s.
         vehicle = connect('tcp:127.0.0.1:5760', wait_ready=True, heartbeat_timeout=20)
 
+        vehicle.close()
+
         # Should not pass
         assert False
     except:

--- a/dronekit/test/sitl/test_waypoints.py
+++ b/dronekit/test/sitl/test_waypoints.py
@@ -41,6 +41,8 @@ def test_set_home(connpath):
     assert_equals(vehicle.home_location.lon, 149)
     assert_equals(vehicle.home_location.alt, 600)
 
+    vehicle.close()
+
 
 @with_sitl
 def test_parameter(connpath):
@@ -139,3 +141,5 @@ def test_227(connpath):
     vehicle.flush()  # Send commands
 
     assert_commands(1)
+
+    vehicle.close()


### PR DESCRIPTION
If Vehicle instances are left unclosed, the latest pymavlink (2.2.20) will spam a lot of "EOF on TCP socket" warning messages:
https://github.com/ArduPilot/pymavlink/issues/230

This commit fixes the issue and allows DroneKit to be used with the latest pymavlink.
In turn, this will enable full Python 3 compatibility for DroneKit. :-)