### PR TITLE
Update pymavlink for Python 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ jobs:
     working_directory: ~/dronekit-python2
     <<: *commonsteps
 
-#  python3:
-#    docker:
-#      - image: circleci/python:3.6-stretch
-#    working_directory: ~/dronekit-python3
-#    <<: *commonsteps
+  python3:
+    docker:
+      - image: circleci/python:3.6-stretch
+    working_directory: ~/dronekit-python3
+    <<: *commonsteps
 
   deploy:
     name: Deploy to dronekit.io
@@ -77,7 +77,7 @@ workflows:
   build_test_deploy:
     jobs:
       - python2
-#      - python3
+      - python3
 #      disabling until we find a new docs server
 #      - deploy:
 #          requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymavlink>=2.2.3
+pymavlink>=2.2.20
 monotonic>=1.3
 future>=0.15.2
 nose==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='dronekit',
       url='https://github.com/dronekit/dronekit-python',
       author='3D Robotics',
       install_requires=[
-          'pymavlink>=2.2.3',
+          'pymavlink>=2.2.20',
           'monotonic==1.2',
           'future==0.15.2'
       ],


### PR DESCRIPTION
pymavlink has been fixed ([1](https://github.com/ArduPilot/pymavlink/commit/5e97b20eeb255a8c956fce9366e71207f00e8484), [2](https://github.com/ArduPilot/pymavlink/commit/4d9c2754c64a7d02fa86b0043335269859e9028a), [3](https://github.com/ArduPilot/pymavlink/commit/4026f1df0f2bfd0925e307a34af7eaa348e0597d)) to correctly handle strings in both Python 2 and Python 3.

This means that with the latest pymavlink release, the SITL tests are finally passing for Python 3 also.

This PR bumps the pymavlink dependency to the latest stable version and re-enables the CircleCI Python 3 tests.