### PR TITLE
pymavlink: Python 3 compatibility fix

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1310,7 +1310,7 @@ class Vehicle(HasObservers):
                 c = 0
                 for i, v in enumerate(self._params_set):
                     if v is None:
-                        self._master.mav.param_request_read_send(0, 0, '', i)
+                        self._master.mav.param_request_read_send(0, 0, b'', i)
                         c += 1
                         if c > 50:
                             break


### PR DESCRIPTION
In the last weeks, pymavlink changed the way it handles strings and bytes in Python 3.
In particular, the `param_request_read_send()` function now accepts the parameter name only as bytes and not as string (references: [1](https://github.com/ArduPilot/pymavlink/commit/c16da2f26b2d0f19d692e870bbe589e7a39bb6b1), [2](https://github.com/ArduPilot/pymavlink/commit/5e97b20eeb255a8c956fce9366e71207f00e8484)).

This breaks Python 3 compatibility for DroneKit in some cases, namely when the line of code affected by this PR gets called in the Vehicle initialization phase (initial download of parameters).
I noticed this behaviour in the SITL tests, running on Python 3.7:
* `SITL_SPEEDUP=10 nosetests`: everything is OK, because that line of code never gets called
* `nosetests`: each test gets stuck at the "Calibrating barometer" phase, and times out

With this fix, the tests run correctly under Python 3 in both cases.