### PR TITLE
Fix virtualenv installation for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,6 @@ common: &commonsteps
     - checkout
 
     - run:
-        name: Install global tools
-        command: |
-          pip install -U virtualenv
-
-    - run:
         name: Install dronekit with dependencies
         command: |
           virtualenv venv


### PR DESCRIPTION
For some reason the CircleCI builds started failing, complaining about a permission error in installing virtualenv at the system level.

It turns out that virtualenv is already bundled in the Docker images: there's no need to install it.