### PR TITLE
Travis: build for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 python:
   - 2.7
-  #- 3.6
+  - 3.6
 
 before_install:
   - pip install --upgrade pip


### PR DESCRIPTION
Enable Travis build & tests for Python 3.6, resolving issue #816.