### PR TITLE
mavlink.py: specific exception handling for MAVError

### DIFF
--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -218,11 +218,15 @@ class MAVConnection(object):
                             if error.errno == ECONNABORTED:
                                 raise APIException('Connection aborting during send')
                             raise
-                        except Exception as e:
-                            # TODO this should be more rigorous. How to avoid
+                        except mavutil.mavlink.MAVError as e:
+                            # Avoid
                             #   invalid MAVLink prefix '73'
                             #   invalid MAVLink prefix '13'
-                            # errprinter('mav recv error:', e)
+                            #errprinter('mav recv error:', e)
+                            msg = None
+                        except Exception as e:
+                            # Log any other unexpected exception
+                            errprinter('>>> Exception while receiving message: ', e)
                             msg = None
                         if not msg:
                             break


### PR DESCRIPTION
In `mavlink.py`, in `mavlink_thread_in`, specifically catch and ignore `MAVError` (the sporadic messages "invalid MAVLink prefix..." are all MAVErrors), avoiding to swallow legitimate exceptions with a broad `except` clause.

This patch should make it easier to debug DroneKit + pymavlink as library code for developers: it's very hard to diagnose problems if the program silently fails.