### PR TITLE
Logging: use builtin logging module for library and autopilot output

### DIFF
--- a/dronekit/test/sitl/test_errprinter.py
+++ b/dronekit/test/sitl/test_errprinter.py
@@ -1,0 +1,34 @@
+import logging
+import time
+
+from nose.tools import assert_true
+
+from dronekit import connect
+from dronekit.test import with_sitl
+
+
+@with_sitl
+def test_115(connpath):
+    """Provide a custom status_printer function to the Vehicle and check that
+    the autopilot messages are correctly logged.
+    """
+
+    logging_check = {'ok': False}
+
+    def errprinter_fn(msg):
+        if isinstance(msg, str) and "APM:Copter" in msg:
+            logging_check['ok'] = True
+
+    vehicle = connect(connpath, wait_ready=False, status_printer=errprinter_fn)
+
+    i = 5
+    while not logging_check['ok'] and i > 0:
+        time.sleep(1)
+        i -= 1
+
+    assert_true(logging_check['ok'])
+    vehicle.close()
+
+    # Cleanup the logger
+    autopilotLogger = logging.getLogger('autopilot')
+    autopilotLogger.removeHandler(autopilotLogger.handlers[0])

--- a/dronekit/util.py
+++ b/dronekit/util.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+
+import logging
 import sys
 
 
@@ -9,3 +11,15 @@ def errprinter(*args):
 def logger(*args):
     print(*args, file=sys.stderr)
     sys.stderr.flush()
+
+
+class ErrprinterHandler(logging.Handler):
+    """Logging handler to support the deprecated `errprinter` argument to connect()"""
+
+    def __init__(self, errprinter):
+        logging.Handler.__init__(self)
+        self.errprinter = errprinter
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.errprinter(msg)


### PR DESCRIPTION
## Current situation
DroneKit does not play well in the logging department when it's used as a library.
Indeed, the user has no way to configure DroneKit's logging apart from monkey-patching (#862).

The logging of MAVLink `STATUSTEXT` messages can be configured by providing a `status_printer` function to `connect()`; however, while the `STATUSTEXT` message [provides](https://mavlink.io/en/messages/common.html#STATUSTEXT) the severity level ([`MAV_SEVERITY` enum](https://mavlink.io/en/messages/common.html#MAV_SEVERITY)) in a field, DroneKit ignores it and prints all the messages from the autopilot with the same severity.

Also, when an exception is encountered in an attribute or message handler, the stack trace does not get printed, making debugging more difficult.

Related issues: #118, #862

## Proposed changes
This PR tries to improve the situation by replacing all the uses of `errprinter()` and `print()` with the built-in Python [`logging`](https://docs.python.org/3/library/logging.html) module facilities.
The stack trace is printed (`exc_info=True`) in case of "unexpected" exceptions coming from user's code.

`STATUSTEXT` messages are logged by a separate logger to make it clear which messages are coming from the autopilot and which others are emitted from the DroneKit library; the two loggers may be configured independently.
The `STATUSTEXT` messages are printed with the correct logging level specified by the autopilot: filtering by severity is now possible.
The `status_printer` argument of `connect()` is deprecated.

With the proposed changes, the library user would be able to format, filter, redirect and suppress DroneKit's and the autopilot's log messages at his/her pleasure.

## Logging in tests
A nice side effect of this change is that the tests now run completely silent, because nose [captures](https://nose.readthedocs.io/en/latest/plugins/logcapture.html) all the log messages and prints them only in case of error.

To force the printing of log messages in test output, one can do:
```
nosetests -svx --debug=autopilot,dronekit
```