### PR TITLE
Avoid pinning requirements to specific version (#872)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pymavlink>=2.2.20
 monotonic>=1.3
 future>=0.15.2
-nose==1.3.7
-mock==2.0.0
+nose>=1.3.7
+mock>=2.0.0
 dronekit-sitl==3.2.0
 sphinx-3dr-theme>=0.4.3

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(name='dronekit',
       author='3D Robotics',
       install_requires=[
           'pymavlink>=2.2.20',
-          'monotonic==1.2',
-          'future==0.15.2'
+          'monotonic>=1.2',
+          'future>=0.15.2'
       ],
       author_email='tim@3drobotics.com, kevinh@geeksville.com',
       classifiers=[


### PR DESCRIPTION
Unless there's a specific reason to do so, don't pin requirements to a specific version to avoid incompatibility problems as in #872.

Especially for packages as `monotonic` and `future` which are basically polyfills and *shouldn't* (fingers crossed...) introduce backwards incompatible changes.