### PR TITLE
Add commands and tests for sensor calibration

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2445,7 +2445,6 @@ class Vehicle(HasObservers):
                 0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
             )
 
-        self._logger.critical(calibration_command)
         self.send_mavlink(calibration_command)
 
     def calibrate_accelerometer(self, simple=False):

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2427,7 +2427,7 @@ class Vehicle(HasObservers):
                 1,  # param 2, Automatically retry on failure (0=no retry, 1=retry).
                 1,  # param 3, Save without user input (0=require input, 1=autosave).
                 0,  # param 4, Delay (seconds).
-                1,  # param 5, Autoreboot (0=user reboot, 1=autoreboot).
+                0,  # param 5, Autoreboot (0=user reboot, 1=autoreboot).
                 0,  # param 6, Empty.
                 0,  # param 7, Empty.
             )
@@ -2468,8 +2468,8 @@ class Vehicle(HasObservers):
         )
         self.send_mavlink(calibration_command)
 
-    def calibrate_board_level(self):
-        """Request board level calibration."""
+    def calibrate_vehicle_level(self):
+        """Request vehicle level (accelerometer trim) calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
             self._handler.target_system, 0,  # target_system, target_component

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2397,6 +2397,125 @@ class Vehicle(HasObservers):
 
         self.send_mavlink(reboot_msg)
 
+    def calibrate_gyro(self):
+        """Request gyroscope calibration."""
+
+        calibration_command = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+            0,  # confirmation
+            1,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+            0,  # param 2, 1: magnetometer calibration
+            0,  # param 3, 1: ground pressure calibration
+            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+            0,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            0,  # param 6, 2: airspeed calibration
+            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+        )
+        self.send_mavlink(calibration_command)
+
+    def calibrate_magnetometer(self):
+        """Request magnetometer calibration."""
+
+        # APM requires the MAV_CMD_DO_START_MAG_CAL command, only present in the APM MAVLink dialect
+        if self._autopilot_type == mavutil.mavlink.MAV_AUTOPILOT_ARDUPILOTMEGA:
+            calibration_command = self.message_factory.command_long_encode(
+                0, 0,  # target_system, target_component
+                mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,  # command
+                0,  # confirmation
+                0,  # param 1, uint8_t bitmask of magnetometers (0 means all).
+                1,  # param 2, Automatically retry on failure (0=no retry, 1=retry).
+                1,  # param 3, Save without user input (0=require input, 1=autosave).
+                0,  # param 4, Delay (seconds).
+                1,  # param 5, Autoreboot (0=user reboot, 1=autoreboot).
+                0,  # param 6, Empty.
+                0,  # param 7, Empty.
+            )
+        else:
+            calibration_command = self.message_factory.command_long_encode(
+                0, 0,  # target_system, target_component
+                mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+                0,  # confirmation
+                0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+                1,  # param 2, 1: magnetometer calibration
+                0,  # param 3, 1: ground pressure calibration
+                0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+                0,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+                0,  # param 6, 2: airspeed calibration
+                0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+            )
+
+        self._logger.critical(calibration_command)
+        self.send_mavlink(calibration_command)
+
+    def calibrate_accelerometer(self):
+        """Request accelerometer calibration."""
+
+        calibration_command = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+            0,  # confirmation
+            0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+            0,  # param 2, 1: magnetometer calibration
+            0,  # param 3, 1: ground pressure calibration
+            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+            1,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            0,  # param 6, 2: airspeed calibration
+            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+        )
+        self.send_mavlink(calibration_command)
+
+    def calibrate_accelerometer_simple(self):
+        """Request simple accelerometer calibration."""
+
+        calibration_command = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+            0,  # confirmation
+            0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+            0,  # param 2, 1: magnetometer calibration
+            0,  # param 3, 1: ground pressure calibration
+            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+            4,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            0,  # param 6, 2: airspeed calibration
+            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+        )
+        self.send_mavlink(calibration_command)
+
+    def calibrate_board_level(self):
+        """Request board level calibration."""
+
+        calibration_command = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+            0,  # confirmation
+            0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+            0,  # param 2, 1: magnetometer calibration
+            0,  # param 3, 1: ground pressure calibration
+            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+            2,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            0,  # param 6, 2: airspeed calibration
+            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+        )
+        self.send_mavlink(calibration_command)
+
+    def calibrate_barometer(self):
+        """Request barometer calibration."""
+
+        calibration_command = self.message_factory.command_long_encode(
+            0, 0,  # target_system, target_component
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
+            0,  # confirmation
+            0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
+            0,  # param 2, 1: magnetometer calibration
+            1,  # param 3, 1: ground pressure calibration
+            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
+            0,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            0,  # param 6, 2: airspeed calibration
+            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
+        )
+        self.send_mavlink(calibration_command)
+
 
 class Gimbal(object):
     """

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2397,7 +2397,7 @@ class Vehicle(HasObservers):
 
         self.send_mavlink(reboot_msg)
 
-    def calibrate_gyro(self):
+    def send_calibrate_gyro(self):
         """Request gyroscope calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
@@ -2414,7 +2414,7 @@ class Vehicle(HasObservers):
         )
         self.send_mavlink(calibration_command)
 
-    def calibrate_magnetometer(self):
+    def send_calibrate_magnetometer(self):
         """Request magnetometer calibration."""
 
         # ArduPilot requires the MAV_CMD_DO_START_MAG_CAL command, only present in the ardupilotmega.xml definition
@@ -2447,7 +2447,7 @@ class Vehicle(HasObservers):
 
         self.send_mavlink(calibration_command)
 
-    def calibrate_accelerometer(self, simple=False):
+    def send_calibrate_accelerometer(self, simple=False):
         """Request accelerometer calibration.
 
         :param simple: if True, perform simple accelerometer calibration
@@ -2467,7 +2467,7 @@ class Vehicle(HasObservers):
         )
         self.send_mavlink(calibration_command)
 
-    def calibrate_vehicle_level(self):
+    def send_calibrate_vehicle_level(self):
         """Request vehicle level (accelerometer trim) calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
@@ -2484,7 +2484,7 @@ class Vehicle(HasObservers):
         )
         self.send_mavlink(calibration_command)
 
-    def calibrate_barometer(self):
+    def send_calibrate_barometer(self):
         """Request barometer calibration."""
 
         calibration_command = self.message_factory.command_long_encode(

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2401,7 +2401,7 @@ class Vehicle(HasObservers):
         """Request gyroscope calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
-            0, 0,  # target_system, target_component
+            self._handler.target_system, 0,  # target_system, target_component
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
             0,  # confirmation
             1,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
@@ -2417,10 +2417,10 @@ class Vehicle(HasObservers):
     def calibrate_magnetometer(self):
         """Request magnetometer calibration."""
 
-        # APM requires the MAV_CMD_DO_START_MAG_CAL command, only present in the APM MAVLink dialect
+        # ArduPilot requires the MAV_CMD_DO_START_MAG_CAL command, only present in the ardupilotmega.xml definition
         if self._autopilot_type == mavutil.mavlink.MAV_AUTOPILOT_ARDUPILOTMEGA:
             calibration_command = self.message_factory.command_long_encode(
-                0, 0,  # target_system, target_component
+                self._handler.target_system, 0,  # target_system, target_component
                 mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,  # command
                 0,  # confirmation
                 0,  # param 1, uint8_t bitmask of magnetometers (0 means all).
@@ -2433,7 +2433,7 @@ class Vehicle(HasObservers):
             )
         else:
             calibration_command = self.message_factory.command_long_encode(
-                0, 0,  # target_system, target_component
+                self._handler.target_system, 0,  # target_system, target_component
                 mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
                 0,  # confirmation
                 0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
@@ -2448,35 +2448,21 @@ class Vehicle(HasObservers):
         self._logger.critical(calibration_command)
         self.send_mavlink(calibration_command)
 
-    def calibrate_accelerometer(self):
-        """Request accelerometer calibration."""
+    def calibrate_accelerometer(self, simple=False):
+        """Request accelerometer calibration.
+
+        :param simple: if True, perform simple accelerometer calibration
+        """
 
         calibration_command = self.message_factory.command_long_encode(
-            0, 0,  # target_system, target_component
+            self._handler.target_system, 0,  # target_system, target_component
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
             0,  # confirmation
             0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
             0,  # param 2, 1: magnetometer calibration
             0,  # param 3, 1: ground pressure calibration
             0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
-            1,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
-            0,  # param 6, 2: airspeed calibration
-            0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
-        )
-        self.send_mavlink(calibration_command)
-
-    def calibrate_accelerometer_simple(self):
-        """Request simple accelerometer calibration."""
-
-        calibration_command = self.message_factory.command_long_encode(
-            0, 0,  # target_system, target_component
-            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
-            0,  # confirmation
-            0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
-            0,  # param 2, 1: magnetometer calibration
-            0,  # param 3, 1: ground pressure calibration
-            0,  # param 4, 1: radio RC calibration, 2: RC trim calibration
-            4,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
+            4 if simple else 1,  # param 5, 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration
             0,  # param 6, 2: airspeed calibration
             0,  # param 7, 1: ESC calibration, 3: barometer temperature calibration
         )
@@ -2486,7 +2472,7 @@ class Vehicle(HasObservers):
         """Request board level calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
-            0, 0,  # target_system, target_component
+            self._handler.target_system, 0,  # target_system, target_component
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
             0,  # confirmation
             0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration
@@ -2503,7 +2489,7 @@ class Vehicle(HasObservers):
         """Request barometer calibration."""
 
         calibration_command = self.message_factory.command_long_encode(
-            0, 0,  # target_system, target_component
+            self._handler.target_system, 0,  # target_system, target_component
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,  # command
             0,  # confirmation
             0,  # param 1, 1: gyro calibration, 3: gyro temperature calibration

--- a/dronekit/test/sitl/__init__.py
+++ b/dronekit/test/sitl/__init__.py
@@ -1,0 +1,47 @@
+import time
+from contextlib import contextmanager
+from nose.tools import assert_equal
+from pymavlink import mavutil
+
+
+@contextmanager
+def assert_command_ack(
+    vehicle,
+    command_type,
+    ack_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+    timeout=10
+):
+    """Context manager to assert that:
+
+    1) exactly one COMMAND_ACK is received from a Vehicle;
+    2) for a specific command type;
+    3) with the given result;
+    4) within a timeout (in seconds).
+
+    For example:
+
+    .. code-block:: python
+
+        with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
+            vehicle.calibrate_gyro()
+
+    """
+
+    acks = []
+
+    def on_ack(self, name, message):
+        if message.command == command_type:
+            acks.append(message)
+
+    vehicle.add_message_listener('COMMAND_ACK', on_ack)
+
+    yield
+
+    start_time = time.time()
+    while not acks and time.time() - start_time < timeout:
+        time.sleep(0.1)
+    vehicle.remove_message_listener('COMMAND_ACK', on_ack)
+
+    assert_equal(1, len(acks))  # one and only one ACK
+    assert_equal(command_type, acks[0].command)  # for the correct command
+    assert_equal(ack_result, acks[0].result)  # the result must be successful

--- a/dronekit/test/sitl/test_sensor_calibration.py
+++ b/dronekit/test/sitl/test_sensor_calibration.py
@@ -45,9 +45,9 @@ def test_simple_accelerometer_calibration(connpath):
         vehicle,
         mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
         timeout=30,
-        ack_result=mavutil.mavlink.MAV_RESULT_FAILED,  # TODO: change when APM is upgraded
+        ack_result=mavutil.mavlink.MAV_RESULT_FAILED,
     ):
-        vehicle.calibrate_accelerometer_simple()
+        vehicle.calibrate_accelerometer(simple=True)
 
     vehicle.close()
 
@@ -66,7 +66,7 @@ def test_accelerometer_calibration(connpath):
         timeout=30,
         ack_result=mavutil.mavlink.MAV_RESULT_FAILED,
     ):
-        vehicle.calibrate_accelerometer()
+        vehicle.calibrate_accelerometer(simple=False)
 
     vehicle.close()
 

--- a/dronekit/test/sitl/test_sensor_calibration.py
+++ b/dronekit/test/sitl/test_sensor_calibration.py
@@ -13,7 +13,7 @@ def test_gyro_calibration(connpath):
     vehicle = connect(connpath, wait_ready=True)
 
     with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
-        vehicle.calibrate_gyro()
+        vehicle.send_calibrate_gyro()
 
     vehicle.close()
 
@@ -30,7 +30,7 @@ def test_magnetometer_calibration(connpath):
         timeout=30,
         ack_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,  # TODO: change when APM is upgraded
     ):
-        vehicle.calibrate_magnetometer()
+        vehicle.send_calibrate_magnetometer()
 
     vehicle.close()
 
@@ -47,7 +47,7 @@ def test_simple_accelerometer_calibration(connpath):
         timeout=30,
         ack_result=mavutil.mavlink.MAV_RESULT_FAILED,
     ):
-        vehicle.calibrate_accelerometer(simple=True)
+        vehicle.send_calibrate_accelerometer(simple=True)
 
     vehicle.close()
 
@@ -66,7 +66,7 @@ def test_accelerometer_calibration(connpath):
         timeout=30,
         ack_result=mavutil.mavlink.MAV_RESULT_FAILED,
     ):
-        vehicle.calibrate_accelerometer(simple=False)
+        vehicle.send_calibrate_accelerometer(simple=False)
 
     vehicle.close()
 
@@ -78,7 +78,7 @@ def test_board_level_calibration(connpath):
     vehicle = connect(connpath, wait_ready=True)
 
     with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
-        vehicle.calibrate_vehicle_level()
+        vehicle.send_calibrate_vehicle_level()
 
     vehicle.close()
 
@@ -90,6 +90,6 @@ def test_barometer_calibration(connpath):
     vehicle = connect(connpath, wait_ready=True)
 
     with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
-        vehicle.calibrate_barometer()
+        vehicle.send_calibrate_barometer()
 
     vehicle.close()

--- a/dronekit/test/sitl/test_sensor_calibration.py
+++ b/dronekit/test/sitl/test_sensor_calibration.py
@@ -78,7 +78,7 @@ def test_board_level_calibration(connpath):
     vehicle = connect(connpath, wait_ready=True)
 
     with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
-        vehicle.calibrate_board_level()
+        vehicle.calibrate_vehicle_level()
 
     vehicle.close()
 

--- a/dronekit/test/sitl/test_sensor_calibration.py
+++ b/dronekit/test/sitl/test_sensor_calibration.py
@@ -1,0 +1,95 @@
+from pymavlink import mavutil
+
+from dronekit import connect
+from dronekit.test import with_sitl
+
+from dronekit.test.sitl import assert_command_ack
+
+
+@with_sitl
+def test_gyro_calibration(connpath):
+    """Request gyroscope calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
+        vehicle.calibrate_gyro()
+
+    vehicle.close()
+
+
+@with_sitl
+def test_magnetometer_calibration(connpath):
+    """Request magnetometer calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    with assert_command_ack(
+        vehicle,
+        mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+        timeout=30,
+        ack_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,  # TODO: change when APM is upgraded
+    ):
+        vehicle.calibrate_magnetometer()
+
+    vehicle.close()
+
+
+@with_sitl
+def test_simple_accelerometer_calibration(connpath):
+    """Request simple accelerometer calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    with assert_command_ack(
+        vehicle,
+        mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+        timeout=30,
+        ack_result=mavutil.mavlink.MAV_RESULT_FAILED,  # TODO: change when APM is upgraded
+    ):
+        vehicle.calibrate_accelerometer_simple()
+
+    vehicle.close()
+
+
+@with_sitl
+def test_accelerometer_calibration(connpath):
+    """Request accelerometer calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    # The calibration is expected to fail because in the SITL we don't tilt the Vehicle.
+    # We just check that the command isn't denied or unsupported.
+    with assert_command_ack(
+        vehicle,
+        mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+        timeout=30,
+        ack_result=mavutil.mavlink.MAV_RESULT_FAILED,
+    ):
+        vehicle.calibrate_accelerometer()
+
+    vehicle.close()
+
+
+@with_sitl
+def test_board_level_calibration(connpath):
+    """Request board level calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
+        vehicle.calibrate_board_level()
+
+    vehicle.close()
+
+
+@with_sitl
+def test_barometer_calibration(connpath):
+    """Request barometer calibration, and check for the COMMAND_ACK."""
+
+    vehicle = connect(connpath, wait_ready=True)
+
+    with assert_command_ack(vehicle, mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, timeout=30):
+        vehicle.calibrate_barometer()
+
+    vehicle.close()


### PR DESCRIPTION
When handling a drone fleet, it is useful to calibrate the drones from DroneKit's API without resorting to QGroundControl, which requires manual operation.
This is especially true for the calibrations which don't require any manual intervention (gyro, barometer, board level), since they can be carried out on the entire fleet in parallel.

In this PR, I added the support for the calibration of:
1) Magnetometer
2) Accelerometer
3) "Simple accelerometer" calibration
4) Barometer
5) Gyroscope
6) Board level

To test the commands, I developed a generic function able to listen to the `COMMAND_ACK` messages and to assert that a specific command has been ACKed.

The accelerometer calibrations are expected to return the `MAV_RESULT_FAILED` status, since in the SITL there's nobody moving the drone.
Still, it's useful to check the ACK status to make sure that the autopilot does not respond with an "unsupported" or "denied" status.

The magnetometer calibration is expected to return the `MAV_RESULT_UNSUPPORTED` status in the tests because the `MAV_CMD_DO_START_MAG_CAL` is not supported in APM Copter 3.3 (the current version of the SITL), however it is supported in the latest ArduPilot master.
PX4, on the other hand, handles the magnetometer calibration using the standard `MAV_CMD_PREFLIGHT_CALIBRATION` message, so I had to handle the two cases in `Vehicle.calibrate_magnetometer()`.