### PR TITLE
in case None > int case error in python3

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1775,7 +1775,7 @@ class Vehicle(HasObservers):
         # check that mode is not INITIALSING
         # check that we have a GPS fix
         # check that EKF pre-arm is complete
-        return self.mode != 'INITIALISING' and self.gps_0.fix_type > 1 and self._ekf_predposhorizabs
+        return self.mode != 'INITIALISING' and (self.gps_0.fix_type is not None and self.gps_0.fix_type > 1) and self._ekf_predposhorizabs
 
     @property
     def system_status(self):


### PR DESCRIPTION
default fix_type None with use campare with 1 in is_armable function, this will case 
`TypeError: '>' not supported between instances of 'NoneType' and 'int'`