### PR TITLE
setup.py, requirements.txt, README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![dronekit_python_logo](https://cloud.githubusercontent.com/assets/5368500/10805537/90dd4b14-7e22-11e5-9592-5925348a7df9.png)
 
-![PyPi published version](https://img.shields.io/pypi/v/dronekit.svg)
+[![PyPi published version](https://img.shields.io/pypi/v/dronekit.svg)](https://pypi.org/project/dronekit/)
 [![Windows Build status](https://img.shields.io/appveyor/ci/3drobotics/dronekit-python/master.svg?label=windows)](https://ci.appveyor.com/project/3drobotics/dronekit-python/branch/master)
 [![OS X Build Status](https://img.shields.io/travis/dronekit/dronekit-python/master.svg?label=os%20x)](https://travis-ci.org/dronekit/dronekit-python)
 [![Linux Build Status](https://img.shields.io/circleci/project/dronekit/dronekit-python/master.svg?label=linux)](https://circleci.com/gh/dronekit/dronekit-python) <a href="https://gitter.im/dronekit/dronekit-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img align="right" src="https://badges.gitter.im/Join%20Chat.svg"></img></a>
@@ -25,12 +25,12 @@ The [Quick Start](http://python.dronekit.io/guide/quick_start.html) guide explai
 A basic script looks like this:
 
 ```python
-from dronekit import connect, VehicleMode
+from dronekit import connect
 
 # Connect to UDP endpoint.
 vehicle = connect('127.0.0.1:14550', wait_ready=True)
 # Use returned Vehicle object to query device state - e.g. to get the mode:
-print " Mode: %s" % vehicle.mode.name
+print("Mode: %s" % vehicle.mode.name)
 ```
 
 Once you've got DroneKit set up, the [guide](http://python.dronekit.io/guide/index.html) explains how to perform operations like taking off and flying the vehicle. You can also try out most of the tasks by running the [examples](http://python.dronekit.io/examples/index.html).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pymavlink>=2.2.20
 monotonic>=1.3
-future>=0.15.2
 nose>=1.3.7
 mock>=2.0.0
 dronekit-sitl==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     author='3D Robotics',
     install_requires=[
         'pymavlink>=2.2.20',
-        'monotonic>=1.3 ; python_version<"3.3"',
+        'monotonic>=1.3',
     ],
     author_email='tim@3drobotics.com, kevinh@geeksville.com',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,30 @@
-from setuptools import setup, Extension
-import platform
+import setuptools
 
 version = '2.9.1'
 
-setup(name='dronekit',
-      zip_safe=True,
-      version=version,
-      description='Developer Tools for Drones.',
-      long_description='Python API for communication and control of drones over MAVLink.',
-      url='https://github.com/dronekit/dronekit-python',
-      author='3D Robotics',
-      install_requires=[
-          'pymavlink>=2.2.20',
-          'monotonic>=1.2',
-          'future>=0.15.2'
-      ],
-      author_email='tim@3drobotics.com, kevinh@geeksville.com',
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Console',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: Apache Software License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python :: 2.7',
-          'Topic :: Scientific/Engineering',
-      ],
-      license='apache',
-      packages=[
-          'dronekit', 'dronekit.test'
-      ],
-      ext_modules=[])
+setuptools.setup(
+    name='dronekit',
+    zip_safe=True,
+    version=version,
+    description='Developer Tools for Drones.',
+    long_description='Python API for communication and control of drones over MAVLink.',
+    url='https://github.com/dronekit/dronekit-python',
+    author='3D Robotics',
+    install_requires=[
+        'pymavlink>=2.2.20',
+        'monotonic>=1.3 ; python_version<"3.3"',
+    ],
+    author_email='tim@3drobotics.com, kevinh@geeksville.com',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Topic :: Scientific/Engineering',
+    ],
+    license='apache',
+    packages=setuptools.find_packages()
+)


### PR DESCRIPTION
This PR contains various improvements to setup.py, requirements.txt and README.md.

- future is not a direct dependency of dronekit: remove it (it will be installed by pymavlink)
- `README.md`: Python 3-compatible "Hello World"
- PyPI badge: link to the package page on PyPI
- `setup.py`: add classifier for Python 3
- `setup.py`: automatically discover packages with `setuptools` (subpackages of the `test` package have been missing)