### PR TITLE
add MOUNT_ORIENTATION support

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2542,6 +2542,13 @@ class Gimbal(object):
             self._yaw = m.pointing_c / 100.0
             vehicle.notify_attribute_listeners('gimbal', vehicle.gimbal)
 
+        @vehicle.on_message('MOUNT_ORIENTATION')
+        def listener(vehicle, name, m):
+            self._pitch = m.pitch 
+            self._roll = m.roll
+            self._yaw = m.yaw
+            vehicle.notify_attribute_listeners('gimbal', vehicle.gimbal)
+
     @property
     def pitch(self):
         """


### PR DESCRIPTION
mavlink2 use MOUNT_ORIENTATION as gimbal status https://mavlink.io/en/messages/common.html#MOUNT_ORIENTATION,
add these code to support gimbal status in mavlink2