### PR TITLE
Allowing specification of timeout for uploading missions

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -3009,7 +3009,7 @@ class CommandSequence(object):
         self._vehicle._wploader.add(cmd, comment='Added by DroneKit')
         self._vehicle._wpts_dirty = True
 
-    def upload(self):
+    def upload(self, timeout=None):
         """
         Call ``upload()`` after :py:func:`adding <CommandSequence.add>` or :py:func:`clearing <CommandSequence.clear>` mission commands.
 
@@ -3018,10 +3018,13 @@ class CommandSequence(object):
         """
         if self._vehicle._wpts_dirty:
             self._vehicle._master.waypoint_clear_all_send()
+            start_time = time.time()
             if self._vehicle._wploader.count() > 0:
                 self._vehicle._wp_uploaded = [False] * self._vehicle._wploader.count()
                 self._vehicle._master.waypoint_count_send(self._vehicle._wploader.count())
                 while False in self._vehicle._wp_uploaded:
+                    if timeout and time.time() - start_time > timeout:
+                        raise TimeoutError
                     time.sleep(0.1)
                 self._vehicle._wp_uploaded = None
             self._vehicle._wpts_dirty = False

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -3015,6 +3015,8 @@ class CommandSequence(object):
 
         After the return from ``upload()`` any writes are guaranteed to have completed (or thrown an
         exception) and future reads will see their effects.
+
+        :param int timeout: The timeout for uploading the mission. No timeout if not provided or set to None.
         """
         if self._vehicle._wpts_dirty:
             self._vehicle._master.waypoint_clear_all_send()


### PR DESCRIPTION
Without a timeout, uploading missions can get stuck in an infinite loop if a buggy version of vehicle refuses to accept the mission. With a timeout parameter, the infinite loop can be avoided.