### PR TITLE
fix URL to mavproxy documentation

### DIFF
--- a/docs/guide/connecting_vehicle.rst
+++ b/docs/guide/connecting_vehicle.rst
@@ -5,10 +5,10 @@
 Connecting to a Vehicle
 =======================
 
-The connection to the vehicle (or multiple vehicles) is set up within the 
-DroneKit script. Scripts import and call the :py:func:`connect() <dronekit.connect>` 
-method. After connecting this returns a :py:class:`Vehicle <dronekit.Vehicle>` 
-object from which you can get/set parameters and attributes, and control vehicle movement. 
+The connection to the vehicle (or multiple vehicles) is set up within the
+DroneKit script. Scripts import and call the :py:func:`connect() <dronekit.connect>`
+method. After connecting this returns a :py:class:`Vehicle <dronekit.Vehicle>`
+object from which you can get/set parameters and attributes, and control vehicle movement.
 
 The most common way to call :py:func:`connect() <dronekit.connect>` is shown below:
 
@@ -19,7 +19,7 @@ The most common way to call :py:func:`connect() <dronekit.connect>` is shown bel
     # Connect to the Vehicle (in this case a UDP endpoint)
     vehicle = connect('127.0.0.1:14550', wait_ready=True)
 
-The first parameter specifies the target address (in this case the loopback 
+The first parameter specifies the target address (in this case the loopback
 address for UDP port 14550). See :ref:`get_started_connect_string` for the strings to use for
 other common vehicles.
 
@@ -41,9 +41,9 @@ Connecting over a serial device will look something like this:
   If the baud rate is not set correctly, ``connect`` may fail with a
   timeout error.  It is best to set the baud rate explicitly.
 
-:py:func:`connect() <dronekit.connect>` also has arguments for setting the baud rate, 
-the length of the connection timeout, and/or to use 
-a :ref:`custom vehicle class <example_create_attribute>`. 
+:py:func:`connect() <dronekit.connect>` also has arguments for setting the baud rate,
+the length of the connection timeout, and/or to use
+a :ref:`custom vehicle class <example_create_attribute>`.
 
 There is more documentation on all of the parameters in the :py:func:`API Reference <dronekit.connect>`.
 
@@ -79,20 +79,20 @@ The table below shows *connection strings* you can use for some of the more comm
 
 .. tip::
 
-    The strings above are the same as are used when connecting the MAVProxy GCS. For other options see the 
-    `MAVProxy documentation <http://dronecode.github.io/MAVProxy/html/getting_started/starting.html#master>`_.
-    
+    The strings above are the same as are used when connecting the MAVProxy GCS. For other options see the
+    `MAVProxy documentation <http://ardupilot.github.io/MAVProxy/html/getting_started/starting.html>`_.
+
 .. note::
 
     The default baud rate may not be appropriate for all connection types (this may be the cause
     if you can connect via a GCS but not DroneKit).
 
-    
+
 Connecting to multiple vehicles
 ===============================
-  
+
 You can control multiple vehicles from within a single script by calling
-:py:func:`connect() <dronekit.connect>` for each vehicle 
+:py:func:`connect() <dronekit.connect>` for each vehicle
 with the appropriate :ref:`connection strings <connection_string_options>`.
 
 The returned :py:class:`Vehicle <dronekit.Vehicle>` objects are independent of


### PR DESCRIPTION
I think this link is now supposed to go to http://ardupilot.github.io/MAVProxy/html/getting_started/starting.html

- [ ] Um, I'm unsure why all lines are modified. Fixing.