### PR TITLE
Fixed minor error in doc example code comments

### DIFF
--- a/docs/guide/connecting_vehicle.rst
+++ b/docs/guide/connecting_vehicle.rst
@@ -33,7 +33,7 @@ Connecting over a serial device will look something like this:
 
     from dronekit import connect
 
-    # Connect to the Vehicle (in this case a UDP endpoint)
+    # Connect to the Vehicle (in this case a serial endpoint)
     vehicle = connect('/dev/ttyAMA0', wait_ready=True, baud=57600)
 
 .. tip::


### PR DESCRIPTION
The serial example code said it was for a UDP endpoint. Docs rebuilt fine.