### PR TITLE
Channels: fix wrong key type

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -789,10 +789,10 @@ class Channels(dict):
     def _update_channel(self, channel, value):
         # If we have channels on different ports, we expand the Channels
         # object to support them.
-        channel = int(channel)
         self._readonly = False
         self[channel] = value
         self._readonly = True
+        channel = int(channel)
         self._count = max(self._count, channel)
 
     @property


### PR DESCRIPTION
It returns None in all channel because of wrong key type.
```
vehicle = connect("127.0.0.1:14550", wait_ready=True)
vehcie.channels
{'1': None, '2': None, '3': None, '4': None, '5': None, '6': None, '7': None, '8': None}
```