### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/about/migrating.rst
+++ b/docs/about/migrating.rst
@@ -249,7 +249,7 @@ Observing attribute changes
 The DroneKit-Python 1.x observer function ``vehicle.add_attribute_observer`` has been replaced by 
 :py:func:`Vehicle.add_attribute_listener() <dronekit.Vehicle.add_attribute_listener>` or 
 :py:func:`Vehicle.on_attribute() <dronekit.Vehicle.on_attribute>` in DKYP2.x,  and ``Vehicle.remove_attribute_observer`` 
-has been repaced by :py:func:`remove_attribute_listener() <dronekit.Vehicle.remove_attribute_listener>`.
+has been replaced by :py:func:`remove_attribute_listener() <dronekit.Vehicle.remove_attribute_listener>`.
 
 The main difference is that the callback function now takes three arguments (the vehicle object, attribute name, attribute value)
 rather than just the attribute name. This allows you to more easily write callbacks that support attribute-specific and 

--- a/docs/guide/vehicle_state_and_parameters.rst
+++ b/docs/guide/vehicle_state_and_parameters.rst
@@ -250,7 +250,7 @@ The example below shows how you can declare an attribute callback using the
 .. note::
 
     The fragment above stores the result of the previous callback and only prints the output when there is a 
-    signficant change in :py:attr:`Vehicle.rangefinder <dronekit.Vehicle.rangefinder>`. You might want to
+    significant change in :py:attr:`Vehicle.rangefinder <dronekit.Vehicle.rangefinder>`. You might want to
     perform caching like this to ignore updates that are not significant to your code.
         
 The examples above show how you can monitor a single attribute. You can pass the special name ('``*``') to specify a 

--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2851,7 +2851,7 @@ class Parameters(collections.MutableMapping, HasObservers):
 
     def remove_attribute_listener(self, attr_name, *args, **kwargs):
         """
-        Remove a paremeter listener that was previously added using :py:func:`add_attribute_listener`.
+        Remove a parameter listener that was previously added using :py:func:`add_attribute_listener`.
 
         For example to remove the ``thr_min_callback()`` callback function:
 


### PR DESCRIPTION
There are small typos in:
- docs/about/migrating.rst
- docs/guide/vehicle_state_and_parameters.rst
- dronekit/__init__.py

Fixes:
- Should read `significant` rather than `signficant`.
- Should read `replaced` rather than `repaced`.
- Should read `parameter` rather than `paremeter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md