### PR TITLE
allow specific target system

### DIFF
--- a/dronekit/mavlink.py
+++ b/dronekit/mavlink.py
@@ -281,7 +281,7 @@ class MAVConnection(object):
 
     def fix_targets(self, message):
         """Set correct target IDs for our vehicle"""
-        if hasattr(message, 'target_system'):
+        if hasattr(message, 'target_system') and message.target_system < 0:
             message.target_system = self.target_system
 
     def forward_loop(self, fn):


### PR DESCRIPTION
The current implementation overwrites any target_system value in a message constructed with the message_factory.
It uses the value it sees from the heartbeat messages, but this might not be the wanted system.

I see that dronekit is created with one target system in mind, but it does not allow a companion computer to talk directly to the ground station.

Imagine connecting a companion computer to an autopilot. The system id of both is 1. The autopilot has component id 1 and the companion computer the id 191. We use a GCS with sys id 250 and comp id 191 (it will be a separate script running next to missionplanner, both connected with mavlink-router). I want to use the TUNNEL message in the future, but there seems to be another problem, so I will use LOGGING_DATA(https://github.com/dronekit/dronekit-python/issues/266) as a replacement for now.

The ground station gets hearbeats from the system id 1 only and the fix_target function will set the target_system value of the message to 1 and this message is delivered successfully. The companion computer running another python script with dronekit receives also the hearbeat message from the autopilot with id 1. The message will now get a target_system of 1 and will only be delivered to itself(so destroyed).

I suggest allowing the user to specify a value >=0 as target system to specify where he wants the message delivered exactly and only fixing the target id when he sets the value to <0. Additionally this target_system value could be set to -1 by default if that helps keeping the same default behaviour.