### PR TITLE
Make HEARTBEAT handler ignore non-vehicle HEARTBEATs

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1249,7 +1249,7 @@ class Vehicle(HasObservers):
         @self.on_message('HEARTBEAT')
         def listener(self, name, m):
             # ignore groundstations
-            if m.type == mavutil.mavlink.MAV_TYPE_GCS:
+            if m.type == mavutil.mavlink.MAV_TYPE_GCS or (not self._handler.master.probably_vehicle_heartbeat(m)):
                 return
             self._armed = (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED) != 0
             self.notify_attribute_listeners('armed', self.armed, cache=True)
@@ -1413,7 +1413,7 @@ class Vehicle(HasObservers):
         @self.on_message(['HEARTBEAT'])
         def listener(self, name, msg):
             # ignore groundstations
-            if msg.type == mavutil.mavlink.MAV_TYPE_GCS:
+            if msg.type == mavutil.mavlink.MAV_TYPE_GCS or (not self._handler.master.probably_vehicle_heartbeat(msg)):
                 return
             self._heartbeat_system = msg.get_srcSystem()
             self._heartbeat_lastreceived = monotonic.monotonic()


### PR DESCRIPTION
Hi, this fixes #1187 . Check the issue for more details.

TL;DR (the two lines :) ): use mavutil's `probably_vehicle_heartbeat` function to avoid trying to parse non-vehicle HEARTBEATs.

Do note that this should **not** be merged in until pymavlink releases a new version. It relies on logic introduced in https://github.com/ArduPilot/pymavlink/pull/769 currently on their master.