### PR TITLE
Get RAW values of the servo outputs

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -1752,7 +1752,7 @@ class Vehicle(HasObservers):
     @property
     def wind(self):
         """
-        Current wind status (:pu:class: `Wind`)
+        Current wind status (:py:class: `Wind`)
         """
         if self._wind_direction is None or self._wind_speed is None or self._wind_speed_z is None:
             return None


### PR DESCRIPTION
@morzack Thank you for replying to my email, I would love to be a maintainer of this program!

The RAW value of the servo output can be acquired based on the SERVO_OUTPUT_RAW information.

An object of this type is returned by :py:attr:`Vehicle.servos`.

:param port: Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.
:param servo_raw['1'] ~ servo_raw['16']: Servo output 1 ~ 16 value.