### PR TITLE
Update __init__.py-line no: 2920, class Command argument message type…

### DIFF
--- a/dronekit/__init__.py
+++ b/dronekit/__init__.py
@@ -2917,7 +2917,7 @@ class Parameters(MutableMapping, HasObservers):
         return super(Parameters, self).on_attribute(attr_name, *args, **kwargs)
 
 
-class Command(mavutil.mavlink.MAVLink_mission_item_message):
+class Command(mavutil.mavlink.MAVLink_mission_item_int_message):
     """
     A waypoint object.
 


### PR DESCRIPTION
The Command class in __init__.py uses mavutil.mavlink.MAVLink_mission_item_message for the message type, which uses the less accurate float32 for sending the long and lat parameters. This can be made more accurate if we use the mavutil.mavlink.MAVLink_mission_item_int_message type which uses int32 for sending, and is the recommended implementation. Hence, for the Command class, we have changed the message type to message_item_int since message_item is now depreciated.